### PR TITLE
add exp to generateBearerToken options

### DIFF
--- a/src/service-account/util/Token.ts
+++ b/src/service-account/util/Token.ts
@@ -18,6 +18,7 @@ export type ResponseSignedDataTokens = { token: string, signedToken: string }
 export type BearerTokenOptions = {
   ctx?: string,
   roleIDs?: string[],
+  exp?: number, 
 }
 
 export type SignedDataTokensOptions = {
@@ -84,7 +85,7 @@ function getToken(credentials, options?: BearerTokenOptions): Promise<ResponseTo
         printLog(errorMessages.NotAValidJSON, MessageType.ERROR);
         throw new SkyflowError({ code: 400, description: errorMessages.NotAValidJSON });
       }
-      const expiryTime = Math.floor(Date.now() / 1000) + 3600;
+      const expiryTime = options?.exp !== undefined ? Math.min(Math.max(options.exp), 1) : (Math.floor(Date.now() / 1000) + 3600);
 
       const claims = {
         iss: credentialsObj.clientID,

--- a/src/service-account/util/Token.ts
+++ b/src/service-account/util/Token.ts
@@ -85,7 +85,7 @@ function getToken(credentials, options?: BearerTokenOptions): Promise<ResponseTo
         printLog(errorMessages.NotAValidJSON, MessageType.ERROR);
         throw new SkyflowError({ code: 400, description: errorMessages.NotAValidJSON });
       }
-      const expiryTime = options?.exp !== undefined ? Math.min(Math.max(options.exp), 1) : (Math.floor(Date.now() / 1000) + 3600);
+      const expiryTime = Math.floor(Date.now() / 1000) + (options?.exp !== undefined ? Math.min(Math.max(options.exp), 1) : 3600);
 
       const claims = {
         iss: credentialsObj.clientID,


### PR DESCRIPTION
Hi skyflow team,

This is a PR to enable passing in a custom expiry seconds value to the generateBearerToken function.

If the exp option is set, it will be used to set the exp value on the token with a minimum of 1 second. Otherwise, it will default to 3600 seconds.

Thanks!