### PR TITLE
SK-1887: Support for the combination of tokens and redaction type in the Detokenize API.

### DIFF
--- a/samples/vault-api/detokenzie-records.ts
+++ b/samples/vault-api/detokenzie-records.ts
@@ -9,7 +9,8 @@ import {
     Skyflow, 
     SkyflowError, 
     VaultConfig, 
-    SkyflowConfig 
+    SkyflowConfig, 
+    DetokenizeData
 } from 'skyflow-node';
 
 /**
@@ -46,13 +47,20 @@ async function performDetokenization() {
         const skyflowClient: Skyflow = new Skyflow(skyflowConfig);
 
         // Step 4: Prepare Detokenization Data
-        const detokenizeData: Array<string> = ['token1', 'token2', 'token3']; // Tokens to be detokenized
-        const redactionType: RedactionType = RedactionType.REDACTED;          // Redaction type
+        const detokenizeData: DetokenizeData[] = [
+            {
+              token: "token1",                          // Token to be detokenized
+              redactionType: RedactionType.PLAIN_TEXT,  // Redaction type
+            },
+            {
+              token: "token2",                         // Token to be detokenized 
+              redactionType: RedactionType.MASKED,     // Redaction type
+            },
+          ]; 
 
         // Create Detokenize Request
         const detokenizeRequest: DetokenizeRequest = new DetokenizeRequest(
-            detokenizeData,
-            redactionType
+            detokenizeData
         );
 
         // Configure Detokenize Options

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,7 @@ import UpdateResponse from './vault/model/response/update';
 import FileUploadResponse from './vault/model/response/file-upload';
 import QueryResponse from './vault/model/response/query';
 import InvokeConnectionResponse from './vault/model/response/invoke/invoke';
-import { SkyflowConfig, TokenizeRequestType } from './vault/types';
+import { SkyflowConfig, TokenizeRequestType, DetokenizeData } from './vault/types';
 import VaultConfig from './vault/config/vault';
 import SkyflowError from './error';
 import ConnectionConfig from './vault/config/connection';
@@ -63,6 +63,7 @@ export {
     DetokenizeRequest,
     DetokenizeOptions,
     DetokenizeResponse,
+    DetokenizeData,
     DeleteRequest,
     DeleteResponse,
     UpdateRequest,

--- a/src/utils/validations/index.ts
+++ b/src/utils/validations/index.ts
@@ -738,34 +738,33 @@ export const validateDetokenizeOptions = (detokenizeOptions?: DetokenizeOptions)
 
 export const validateDetokenizeRequest = (detokenizeRequest: DetokenizeRequest, detokenizeOptions?: DetokenizeOptions, logLevel: LogLevel = LogLevel.ERROR) => {
     if (detokenizeRequest) {
-        if (!detokenizeRequest?.tokens) {
+        if (!detokenizeRequest?.data) {
             printLog(logs.errorLogs.EMPTY_TOKENS_IN_DETOKENIZE, MessageType.ERROR, logLevel);
             throw new SkyflowError(SKYFLOW_ERROR_CODE.EMPTY_TOKENS_IN_DETOKENIZE)
         }
 
-        if (!Array.isArray(detokenizeRequest.tokens)) {
+        if (!Array.isArray(detokenizeRequest.data)) {
             printLog(logs.errorLogs.INVALID_TOKENS_IN_DETOKENIZE, MessageType.ERROR, logLevel);
             throw new SkyflowError(SKYFLOW_ERROR_CODE.INVALID_TOKENS_TYPE_IN_DETOKENIZE)
         }
 
-        const tokens = detokenizeRequest?.tokens;
+        const records = detokenizeRequest?.data;
 
-        if (tokens.length === 0)
+        if (records.length === 0)
             throw new SkyflowError(SKYFLOW_ERROR_CODE.EMPTY_TOKENS_IN_DETOKENIZE);
 
-        tokens.forEach((token, index) => {
-            if (!token) {
+        records.forEach((record, index) => {
+            if (!record) {
                 printLog(parameterizedString(logs.errorLogs.INVALID_TOKEN_IN_DETOKENIZE, [index]), MessageType.ERROR, logLevel);
                 throw new SkyflowError(SKYFLOW_ERROR_CODE.EMPTY_TOKEN_IN_DETOKENIZE, [index]);
             }
-            if (typeof token !== 'string' || token.trim().length === 0) {
+            if (typeof record.token !== 'string' || record.token.trim().length === 0) {
                 throw new SkyflowError(SKYFLOW_ERROR_CODE.INVALID_TOKEN_IN_DETOKENIZE, [index]);
             }
+            if (record?.redactionType && (typeof record.redactionType !== 'string' || !isRedactionType(record.redactionType))) {
+                throw new SkyflowError(SKYFLOW_ERROR_CODE.INVALID_REDACTION_TYPE);
+            }
         });
-
-        if (detokenizeRequest?.redactionType && (typeof detokenizeRequest.redactionType !== 'string' || !isRedactionType(detokenizeRequest.redactionType))) {
-            throw new SkyflowError(SKYFLOW_ERROR_CODE.INVALID_REDACTION_TYPE);
-        }
 
         validateDetokenizeOptions(detokenizeOptions);
 

--- a/src/vault/controller/vault/index.ts
+++ b/src/vault/controller/vault/index.ts
@@ -476,7 +476,7 @@ class VaultController {
                 //validations checks
                 validateDetokenizeRequest(request, options, this.client.getLogLevel());
 
-                const fields = request.tokens.map(record => ({ token: record, redaction: request?.redactionType || RedactionType.PLAIN_TEXT })) as Array<V1DetokenizeRecordRequest>;
+                const fields = request.data.map(record => ({ token: record.token, redaction: record?.redactionType || RedactionType.PLAIN_TEXT })) as Array<V1DetokenizeRecordRequest>;
                 const detokenizePayload: V1DetokenizePayload = { detokenizationParameters: fields, continueOnError: options?.getContinueOnError(), downloadURL: options?.getDownloadURL() };
 
                 this.handleRequest(

--- a/src/vault/model/request/detokenize/index.ts
+++ b/src/vault/model/request/detokenize/index.ts
@@ -1,37 +1,24 @@
 //imports
-
-import { RedactionType } from "../../../../utils";
+import { DetokenizeData } from "../../../types";
 
 class DetokenizeRequest {
 
     //fields
-    private _tokens: Array<string>;
-    private _redactionType?: RedactionType;
+    private _data: DetokenizeData[];
 
     // Constructor
-    constructor(tokens: Array<string>, redactionType?: RedactionType) {
-        this._tokens = tokens;
-        this._redactionType = redactionType;
-    }
-
-    // Getter for redactionType
-    public get redactionType(): RedactionType | undefined {
-        return this._redactionType;
-    }
-
-    // Setter for redactionType
-    public set redactionType(value: RedactionType) {
-        this._redactionType = value;
+    constructor(data: DetokenizeData[]) {
+        this._data = data;
     }
 
     // Getter for tokens
-    public get tokens(): Array<string> {
-        return this._tokens;
+    public get data(): DetokenizeData[] {
+        return this._data;
     }
 
     // Setter for tokens
-    public set tokens(value: Array<string>) {
-        this._tokens = value;
+    public set data(value: DetokenizeData[]) {
+        this._data = value;
     }
 
 }

--- a/src/vault/types/index.ts
+++ b/src/vault/types/index.ts
@@ -1,4 +1,4 @@
-import { LogLevel } from "../../utils";
+import { LogLevel, RedactionType } from "../../utils";
 import ConnectionConfig from "../config/connection";
 import VaultConfig from "../config/vault"
 import Credentials from "../config/credentials";
@@ -66,4 +66,9 @@ export interface ErrorInsertBatchResponse {
 export interface ParsedInsertBatchResponse {
     success: insertResponseType[];
     errors: ErrorInsertBatchResponse[];
+}
+
+export interface DetokenizeData {
+    token: string;
+    redactionType: RedactionType;
 }

--- a/test/vault/controller/vault.test.js
+++ b/test/vault/controller/vault.test.js
@@ -392,8 +392,16 @@ describe('VaultController detokenize method', () => {
 
     test('should successfully detokenize records', async () => {
         const mockRequest = {
-            tokens: ['token1', 'token2'],
-            redactionType: 'PLAIN_TEXT',
+            data: [
+                {
+                    'token': 'token1',
+                    'redactionType': 'PLAIN_TEXT'
+                },
+                {
+                    'token': 'token2',
+                    'redactionType': 'PLAIN_TEXT'
+                }
+            ],
         };
         const mockOptions = {
             getContinueOnError: jest.fn().mockReturnValue(true),
@@ -423,7 +431,16 @@ describe('VaultController detokenize method', () => {
 
     test('should successfully detokenize records with different request', async () => {
         const mockRequest = {
-            tokens: ['token1', 'token2'],
+            data: [
+                {
+                    'token': 'token1',
+                    'redactionType': 'PLAIN_TEXT'
+                },
+                {
+                    'token': 'token2',
+                    'redactionType': 'PLAIN_TEXT'
+                }
+            ],
         };
         const mockOptions = {
             getContinueOnError: jest.fn().mockReturnValue(false),
@@ -453,7 +470,16 @@ describe('VaultController detokenize method', () => {
 
     test('should successfully detokenize records with empty options', async () => {
         const mockRequest = {
-            tokens: ['token1', 'token2'],
+            data: [
+                {
+                    'token': 'token1',
+                    'redactionType': 'PLAIN_TEXT'
+                },
+                {
+                    'token': 'token2',
+                    'redactionType': 'PLAIN_TEXT'
+                }
+            ],
         };
 
         const mockDetokenizeResponse = {
@@ -480,8 +506,16 @@ describe('VaultController detokenize method', () => {
 
     test('should return unknown detokenize records', async () => {
         const mockRequest = {
-            tokens: ['token1', 'token2'],
-            redactionType: 'PLAIN_TEXT',
+            data: [
+                {
+                    'token': 'token1',
+                    'redactionType': 'PLAIN_TEXT'
+                },
+                {
+                    'token': 'token2',
+                    'redactionType': 'PLAIN_TEXT'
+                }
+            ]
         };
         const mockOptions = {
             getContinueOnError: jest.fn().mockReturnValue(true),
@@ -525,7 +559,16 @@ describe('VaultController detokenize method', () => {
 
     test('should handle API error during detokenize', async () => {
         const mockRequest = {
-            tokens: ['token1', 'token2']
+            data: [
+                {
+                    'token': 'token1',
+                    'redactionType': 'PLAIN_TEXT'
+                },
+                {
+                    'token': 'token2',
+                    'redactionType': 'PLAIN_TEXT'
+                }
+            ]
         };
         const mockOptions = {
             getContinueOnError: jest.fn().mockReturnValue(true),


### PR DESCRIPTION
**Why**

- The detokenize method takes in an array of tokens and a redaction type that is applied for all tokens in the payload. But detokenize api supports combination of tokens and redaction type.

**Outcome**

- Supporting token and redaction type combinations to make the Node SDK consistent with the API.