### PR TITLE
SK-1901: Add request Ids in response for continue on error failures

### DIFF
--- a/src/vault/types/index.ts
+++ b/src/vault/types/index.ts
@@ -49,6 +49,7 @@ export interface SuccessDetokenizeResponse {
 }
 
 export interface ErrorDetokenizeResponse {
+    requestId: string;
     token: string;
     error: string;
 }
@@ -59,6 +60,7 @@ export interface ParsedDetokenizeResponse {
 }
 
 export interface ErrorInsertBatchResponse {
+    requestId: string;
     requestIndex: number;
     error: string;
 }

--- a/test/vault/controller/vault.test.js
+++ b/test/vault/controller/vault.test.js
@@ -166,7 +166,7 @@ describe('VaultController insert method', () => {
         };
         const mockResponseData = { records: [{ skyflow_id: 'id123', tokens: {} }] };
 
-        mockVaultClient.vaultAPI.recordServiceInsertRecord.mockResolvedValueOnce({ data: mockResponseData });
+        mockVaultClient.vaultAPI.recordServiceInsertRecord.mockResolvedValueOnce({ data: mockResponseData, headers: { 'x-request-id': 'request-id' }});
 
         const response = await vaultController.insert(mockRequest, mockOptions);
 
@@ -195,7 +195,7 @@ describe('VaultController insert method', () => {
         };
         const mockResponseData = { records: [{ skyflow_id: 'id123', tokens: {} }] };
 
-        mockVaultClient.vaultAPI.recordServiceInsertRecord.mockResolvedValueOnce({ data: mockResponseData });
+        mockVaultClient.vaultAPI.recordServiceInsertRecord.mockResolvedValueOnce({ data: mockResponseData, headers: { 'x-request-id': 'request-id' }});
 
         const response = await vaultController.insert(mockRequest, mockOptions);
 
@@ -224,7 +224,7 @@ describe('VaultController insert method', () => {
         };
         const mockResponseData = { skyflow_id: 'id123', tokens: {} };
 
-        mockVaultClient.vaultAPI.recordServiceInsertRecord.mockResolvedValueOnce({ data: mockResponseData });
+        mockVaultClient.vaultAPI.recordServiceInsertRecord.mockResolvedValueOnce({ data: mockResponseData, headers: { 'x-request-id': 'request-id' } });
 
         const response = await vaultController.insert(mockRequest, mockOptions);
 
@@ -253,7 +253,7 @@ describe('VaultController insert method', () => {
         };
         const mockResponseData = { responses: [{ Body: { records: [{ skyflow_id: 'id123' }] }, Status: 200 }, { Body: { records: [{ skyflow_id: 'id123' }] }, Status: 400 }] };
 
-        mockVaultClient.vaultAPI.recordServiceBatchOperation.mockResolvedValueOnce({ data: mockResponseData });
+        mockVaultClient.vaultAPI.recordServiceBatchOperation.mockResolvedValueOnce({ data: mockResponseData, headers: { 'x-request-id': 'request-id' } });
 
         const response = await vaultController.insert(mockRequest, mockOptions);
 
@@ -276,7 +276,7 @@ describe('VaultController insert method', () => {
         };
         const mockResponseData = { responses: [{ Body: { records: [{ skyflow_id: 'id123' }] }, Status: 200 }, null] };
 
-        mockVaultClient.vaultAPI.recordServiceBatchOperation.mockResolvedValueOnce({ data: mockResponseData });
+        mockVaultClient.vaultAPI.recordServiceBatchOperation.mockResolvedValueOnce({ data: mockResponseData, headers: { 'x-request-id': 'request-id' } });
 
         const response = await vaultController.insert(mockRequest, mockOptions);
 
@@ -299,7 +299,7 @@ describe('VaultController insert method', () => {
         };
         const mockResponseData = null;
 
-        mockVaultClient.vaultAPI.recordServiceBatchOperation.mockResolvedValueOnce({ data: mockResponseData });
+        mockVaultClient.vaultAPI.recordServiceBatchOperation.mockResolvedValueOnce({ data: mockResponseData, headers: { 'x-request-id': 'request-id' } });
 
         const response = await vaultController.insert(mockRequest, mockOptions);
 
@@ -322,7 +322,7 @@ describe('VaultController insert method', () => {
         };
         const mockResponseData = [{ Body: { records: [{ skyflow_id: 'id123' }] }, Status: 200 }];
 
-        mockVaultClient.vaultAPI.recordServiceBatchOperation.mockResolvedValueOnce({ data: mockResponseData });
+        mockVaultClient.vaultAPI.recordServiceBatchOperation.mockResolvedValueOnce({ data: mockResponseData, headers: { 'x-request-id': 'request-id' } });
 
         const response = await vaultController.insert(mockRequest, mockOptions);
 
@@ -413,7 +413,8 @@ describe('VaultController detokenize method', () => {
                     { token: 'token1', value: 'value1' },
                     { token: 'token2', error: 'error2' }
                 ]
-            }
+            },
+            headers: { 'x-request-id': 'request-id' }
         };
 
         mockVaultClient.tokensAPI.recordServiceDetokenize.mockResolvedValueOnce(mockDetokenizeResponse);
@@ -452,7 +453,8 @@ describe('VaultController detokenize method', () => {
                     { token: 'token1', value: 'value1' },
                     { token: 'token2', error: 'error2' }
                 ]
-            }
+            },
+            headers: { 'x-request-id': 'request-id' }
         };
 
         mockVaultClient.tokensAPI.recordServiceDetokenize.mockResolvedValueOnce(mockDetokenizeResponse);
@@ -488,7 +490,8 @@ describe('VaultController detokenize method', () => {
                     { token: 'token1', value: 'value1' },
                     { token: 'token2', error: 'error2' }
                 ]
-            }
+            },
+            headers: { 'x-request-id': 'request-id' }
         };
 
         mockVaultClient.tokensAPI.recordServiceDetokenize.mockResolvedValueOnce(mockDetokenizeResponse);
@@ -524,7 +527,8 @@ describe('VaultController detokenize method', () => {
         const mockDetokenizeResponse = {
             data: {
                 records: {}
-            }
+            },
+            headers: { 'x-request-id': 'request-id' }
         };
 
         mockVaultClient.tokensAPI.recordServiceDetokenize.mockResolvedValueOnce(mockDetokenizeResponse);
@@ -655,7 +659,7 @@ describe('VaultController delete method', () => {
         };
         const mockResponseData = { RecordIDResponse: ['id123'] };
 
-        mockVaultClient.vaultAPI.recordServiceBulkDeleteRecord.mockResolvedValueOnce({ data: mockResponseData });
+        mockVaultClient.vaultAPI.recordServiceBulkDeleteRecord.mockResolvedValueOnce({ data: mockResponseData, headers: { 'x-request-id': 'request-id' } });
 
         const response = await vaultController.delete(mockRequest);
 
@@ -709,7 +713,7 @@ describe('VaultController delete method', () => {
         validateDeleteRequest.mockImplementation(() => {
             // throw new Error('Validation error');
         });
-        mockVaultClient.vaultAPI.recordServiceBulkDeleteRecord.mockResolvedValueOnce({ data: mockResponseData });
+        mockVaultClient.vaultAPI.recordServiceBulkDeleteRecord.mockResolvedValueOnce({ data: mockResponseData, headers: { 'x-request-id': 'request-id' } });
 
         const response = await vaultController.delete(mockRequest);
 
@@ -756,7 +760,7 @@ describe('VaultController tokenize method', () => {
         const mockRequest = {
             values: [{ value: 'sensitiveData', columnGroup: 'group1' }],
         };
-        const mockResponseData = { data: { records: [{ token: 'token123' }] } };
+        const mockResponseData = { data: { records: [{ token: 'token123' }] }, headers: { 'x-request-id': 'request-id' } };
 
         mockVaultClient.tokensAPI.recordServiceTokenize.mockResolvedValueOnce(mockResponseData);
 
@@ -860,7 +864,9 @@ describe('VaultController query method', () => {
         const mockResponseData = {data:{ records: [{
             fields: { id: '1', name: 'test' },
             tokens: { id: 'token123' },
-        }]}};
+        }]},
+        headers: { 'x-request-id': 'request-id' }
+        };
 
         mockVaultClient.queryAPI.queryServiceExecuteQuery.mockResolvedValueOnce(mockResponseData);
 
@@ -882,7 +888,7 @@ describe('VaultController query method', () => {
         const mockRequest = {
             query: 'SELECT * FROM table WHERE id=1',
         };
-        const mockResponseData = {data:null};
+        const mockResponseData = {data:null, headers: { 'x-request-id': 'request-id' }};
 
         mockVaultClient.queryAPI.queryServiceExecuteQuery.mockResolvedValueOnce(mockResponseData);
 
@@ -983,7 +989,7 @@ describe('VaultController update method', () => {
             getTokenMode: jest.fn().mockReturnValue("DISABLE"),
             getTokens: jest.fn().mockReturnValue({}),
         };
-        const mockResponseData = {data: { skyflow_id: 'id123', tokens: { field1: 'token123' } }};
+        const mockResponseData = {data: { skyflow_id: 'id123', tokens: { field1: 'token123' } }, headers: { 'x-request-id': 'request-id' }};
 
         mockVaultClient.vaultAPI.recordServiceUpdateRecord.mockResolvedValueOnce(mockResponseData);
 
@@ -1009,7 +1015,7 @@ describe('VaultController update method', () => {
             tableName: 'testTable',
         };
         const mockOptions = null;
-        const mockResponseData = {data: { skyflow_id: 'id123', tokens: { field1: 'token123' } }};
+        const mockResponseData = {data: { skyflow_id: 'id123', tokens: { field1: 'token123' } }, headers: { 'x-request-id': 'request-id' }};
 
         mockVaultClient.vaultAPI.recordServiceUpdateRecord.mockResolvedValueOnce(mockResponseData);
 
@@ -1038,7 +1044,7 @@ describe('VaultController update method', () => {
             getTokenMode: jest.fn().mockReturnValue("ENABLE"),
             getTokens: jest.fn().mockReturnValue({}),
         };
-        const mockResponseData = {data: { skyflow_id: 'id123', tokens: { field1: 'token123' } }};
+        const mockResponseData = {data: { skyflow_id: 'id123', tokens: { field1: 'token123' } }, headers: { 'x-request-id': 'request-id' }};
 
         mockVaultClient.vaultAPI.recordServiceUpdateRecord.mockResolvedValueOnce(mockResponseData);
 
@@ -1171,7 +1177,7 @@ describe('VaultController uploadFile method', () => {
             tableName: 'testTable',
             skyflowId: 'id123',
         };
-        const mockResponseData = {data:{ skyflow_id: 'id123' }};
+        const mockResponseData = {data:{ skyflow_id: 'id123' }, headers: { 'x-request-id': 'request-id' }};
 
         const mockStream = { on: jest.fn() };
         jest.spyOn(mockFs, 'createReadStream').mockReturnValueOnce(mockStream);
@@ -1282,7 +1288,7 @@ describe('VaultController get method', () => {
 
     test('should successfully get records for GetRequest', async () => {
         const mockRequest = createGetRequest(['id1', 'id2']);
-        const mockResponseData = { data: { records: [{ fields: { field1: 'value1' } }, { fields: { field2: 'value2' } }] } };
+        const mockResponseData = { data: { records: [{ fields: { field1: 'value1' } }, { fields: { field2: 'value2' } }] }, headers: { 'x-request-id': 'request-id' } };
 
         mockVaultClient.vaultAPI.recordServiceBulkGetRecord.mockResolvedValueOnce(mockResponseData);
 
@@ -1299,7 +1305,7 @@ describe('VaultController get method', () => {
 
     test('should successfully get records for GetRequest with options', async () => {
         const mockRequest = createGetRequest(['id1', 'id2']);
-        const mockResponseData = { data: { records: [{ fields: { field1: 'value1' } }, { fields: { field2: 'value2' } }] } };
+        const mockResponseData = { data: { records: [{ fields: { field1: 'value1' } }, { fields: { field2: 'value2' } }] }, headers: { 'x-request-id': 'request-id' } };
         const mockOptions = {  
             getRedactionType: jest.fn().mockReturnValue(true),
             getReturnTokens: jest.fn().mockReturnValue(true),
@@ -1325,7 +1331,7 @@ describe('VaultController get method', () => {
 
     test('should successfully get records for GetColumnRequest', async () => {
         const mockRequest = createGetColumnRequest('columnName', ['value1', 'value2']);
-        const mockResponseData = { data: { records:[{ fields: { field1: 'value1' } }]}};
+        const mockResponseData = { data: { records:[{ fields: { field1: 'value1' } }]}, headers: { 'x-request-id': 'request-id' }};
 
         mockVaultClient.vaultAPI.recordServiceBulkGetRecord.mockResolvedValueOnce(mockResponseData);
 


### PR DESCRIPTION
**Why**

- When `continueOnError` flag is set to true, `requestId` is not present for failed requests.
- The absence of `requestId` makes it difficult to debug and troubleshoot these failed requests effectively.

**Outcome**

- `requestId` will be present for detokenize failure responses when `continueOnError` is true
- `requestId` will be present for insert failure responses when `continueOnError` is true