### PR TITLE
SK-2007: Fix skyflow client initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ To use this module, the Skyflow client must first be initialized as follows:
 import { Skyflow } from 'skyflow-node';
 
 // Initialize the Skyflow Vault client
-const client : Skyflow = Skyflow({
+const client : Skyflow = new Skyflow({
   vaultConfigs: [
     {
       // Id of the vault that the client should connect to.


### PR DESCRIPTION
Added new keyword to Skyflow client initialization, so the Readme is initializing an instance of the Class, VS assigning the Class definition to the client variable. 