### PR TITLE
SK-2056: Use unions for credentials instead of interfaces

### DIFF
--- a/src/error/codes/index.ts
+++ b/src/error/codes/index.ts
@@ -61,6 +61,7 @@ const SKYFLOW_ERROR_CODE = {
     MISSING_PRIVATE_KEY: { http_code: 400, message: errorMessages.MISSING_PRIVATE_KEY },
 
     INVALID_ROLES_KEY_TYPE: { http_code: 400, message: errorMessages.INVALID_ROLES_KEY_TYPE },
+    INVALID_CONTEXT: { http_code: 400, message: errorMessages.INVALID_CONTEXT },
     EMPTY_ROLES: { http_code: 400, message: errorMessages.EMPTY_ROLES },
 
     INVALID_JSON_FORMAT: { http_code: 400, message: errorMessages.INVALID_JSON_FORMAT },

--- a/src/error/messages/index.ts
+++ b/src/error/messages/index.ts
@@ -61,6 +61,7 @@ const errorMessages = {
     MISSING_TOKEN_URI: `${errorPrefix} Validation error. Unable to read token URI in credentials. Verify your token URI.`,
 
     INVALID_ROLES_KEY_TYPE: `${errorPrefix} Validation error. Invalid roles. Specify roles as an array.`,
+    INVALID_CONTEXT: `${errorPrefix} Validation error. Invalid context. Specify context as a string.`,
     EMPTY_ROLES: `${errorPrefix} Validation error. Invalid roles. Specify at least one role.`,
 
     INVALID_JSON_FORMAT: `${errorPrefix} Validation error. Credentials is not in valid JSON format. Verify the credentials.`,

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import UpdateRequest from './vault/model/request/update';
 import FileUploadRequest from './vault/model/request/file-upload';
 import QueryRequest from './vault/model/request/query';
 import Credentials from './vault/config/credentials';
+import { TokenCredentials, ApiKeyCredentials, PathCredentials, StringCredentials } from './vault/config/credentials';
 import TokenizeRequest from './vault/model/request/tokenize';
 import TokenizeResponse from './vault/model/response/tokenize';
 import { BearerTokenOptions, generateBearerToken, generateBearerTokenFromCreds, generateSignedDataTokens, generateSignedDataTokensFromCreds, GenerateTokenOptions, SignedDataTokensOptions } from './service-account';
@@ -64,6 +65,10 @@ export {
     generateSignedDataTokensFromCreds,
     isExpired,
     Credentials,
+    ApiKeyCredentials,
+    TokenCredentials,
+    PathCredentials,
+    StringCredentials,
     RedactionType,
     OrderByEnum,
     TokenMode,

--- a/src/utils/validations/index.ts
+++ b/src/utils/validations/index.ts
@@ -3,7 +3,7 @@ import { V1Byot } from "../../ _generated_/rest/api";
 import SkyflowError from "../../error";
 import SKYFLOW_ERROR_CODE from "../../error/codes";
 import ConnectionConfig from "../../vault/config/connection";
-import Credentials from "../../vault/config/credentials";
+import Credentials, { ApiKeyCredentials, PathCredentials, StringCredentials, TokenCredentials } from "../../vault/config/credentials";
 import VaultConfig from "../../vault/config/vault";
 import DetokenizeOptions from "../../vault/model/options/detokenize";
 import GetOptions from "../../vault/model/options/get";
@@ -130,42 +130,74 @@ export const validateSkyflowConfig = (config: SkyflowConfig, logLevel: LogLevel 
 
 
 export const validateCredentialsWithId = (credentials: Credentials, type: string, typeId: string, id: string, logLevel: LogLevel = LogLevel.ERROR) => {
-    // validates types for ctx roles
-    const { token, path, credentialsString, apiKey } = credentials;
-
-    // Count how many of the fields are defined
-    const definedFields = [token, path, credentialsString, apiKey].filter(Boolean).length;
-
-    // If none are present
-    if (definedFields === 0) {
+    if (!credentials) {
         throw new SkyflowError(SKYFLOW_ERROR_CODE.INVALID_CREDENTIALS_WITH_ID, [type, typeId, id]);
     }
 
-    // If more than one is present
-    if (definedFields > 1) {
+    const isTokenCred = 'token' in credentials;
+    const isPathCred = 'path' in credentials;
+    const isStringCred = 'credentialsString' in credentials;
+    const isApiKeyCred = 'apiKey' in credentials;
+
+    // Check if exactly one credential type is provided
+    const definedTypes = [isTokenCred, isPathCred, isStringCred, isApiKeyCred].filter(Boolean).length;
+
+    if (definedTypes === 0) {
+        throw new SkyflowError(SKYFLOW_ERROR_CODE.INVALID_CREDENTIALS_WITH_ID, [type, typeId, id]);
+    }
+
+    if (definedTypes > 1) {
         throw new SkyflowError(SKYFLOW_ERROR_CODE.MULTIPLE_CREDENTIALS_PASSED_WITH_ID, [type, typeId, id]);
     }
 
-    if (credentials?.token && (typeof credentials?.token !== 'string' || isExpired(credentials?.token))) {
-        printLog(logs.errorLogs.EMPTY_TOKEN_VALUE, MessageType.ERROR, logLevel);
-        throw new SkyflowError(SKYFLOW_ERROR_CODE.INVALID_BEARER_TOKEN_WITH_ID, [type, typeId, id]);
+    // Validate TokenCredentials
+    if (isTokenCred) {
+        const tokenCred = credentials as TokenCredentials;
+        if (typeof tokenCred.token !== 'string' || isExpired(tokenCred.token)) {
+            printLog(logs.errorLogs.EMPTY_TOKEN_VALUE, MessageType.ERROR, logLevel);
+            throw new SkyflowError(SKYFLOW_ERROR_CODE.INVALID_BEARER_TOKEN_WITH_ID, [type, typeId, id]);
+        }
     }
 
-    if (credentials?.credentialsString && (typeof credentials?.credentialsString !== 'string' || !isValidCredentialsString(credentials?.credentialsString))) {
-        printLog(logs.errorLogs.EMPTY_CREDENTIALS_STRING, MessageType.ERROR, logLevel);
-        throw new SkyflowError(SKYFLOW_ERROR_CODE.INVALID_PARSED_CREDENTIALS_STRING_WITH_ID, [type, typeId, id]);
+    // Validate PathCredentials
+    if (isPathCred) {
+        console.log("PathCredentials");
+        const pathCred = credentials as PathCredentials;
+        if (typeof pathCred.path !== 'string' || !isValidPath(pathCred.path)) {
+            printLog(logs.errorLogs.EMPTY_CREDENTIALS_PATH, MessageType.ERROR, logLevel);
+            throw new SkyflowError(SKYFLOW_ERROR_CODE.INVALID_FILE_PATH_WITH_ID, [type, typeId, id]);
+        }
+        if (pathCred.roles !== undefined && !Array.isArray(pathCred.roles)) {
+            throw new SkyflowError(SKYFLOW_ERROR_CODE.INVALID_ROLES_KEY_TYPE, [type, typeId, id]);
+        }
+        if (pathCred.context !== undefined && typeof pathCred.context !== 'string') {
+            throw new SkyflowError(SKYFLOW_ERROR_CODE.INVALID_CONTEXT, [type, typeId, id]);
+        }
     }
 
-    if (credentials?.apiKey && (typeof credentials?.apiKey !== 'string' || !isValidAPIKey(credentials?.apiKey))) {
-        printLog(logs.errorLogs.INVALID_API_KEY, MessageType.ERROR, logLevel);
-        throw new SkyflowError(SKYFLOW_ERROR_CODE.INVALID_API_KEY_WITH_ID, [type, typeId, id]);
+    // Validate StringCredentials
+    if (isStringCred) {
+        const stringCred = credentials as StringCredentials;
+        if (typeof stringCred.credentialsString !== 'string' || !isValidCredentialsString(stringCred.credentialsString)) {
+            printLog(logs.errorLogs.EMPTY_CREDENTIALS_STRING, MessageType.ERROR, logLevel);
+            throw new SkyflowError(SKYFLOW_ERROR_CODE.INVALID_PARSED_CREDENTIALS_STRING_WITH_ID, [type, typeId, id]);
+        }
+        if (stringCred.roles !== undefined && !Array.isArray(stringCred.roles)) {
+            throw new SkyflowError(SKYFLOW_ERROR_CODE.INVALID_ROLES_KEY_TYPE, [type, typeId, id]);
+        }
+        if (stringCred.context !== undefined && typeof stringCred.context !== 'string') {
+            throw new SkyflowError(SKYFLOW_ERROR_CODE.INVALID_CONTEXT, [type, typeId, id]);
+        }
     }
 
-    if (credentials?.path && (typeof credentials?.path !== 'string' || !isValidPath(credentials?.path))) {
-        printLog(logs.errorLogs.EMPTY_CREDENTIALS_PATH, MessageType.ERROR, logLevel);
-        throw new SkyflowError(SKYFLOW_ERROR_CODE.INVALID_FILE_PATH_WITH_ID, [type, typeId, id]);
+    // Validate ApiKeyCredentials
+    if (isApiKeyCred) {
+        const apiKeyCred = credentials as ApiKeyCredentials;
+        if (typeof apiKeyCred.apiKey !== 'string' || !isValidAPIKey(apiKeyCred.apiKey)) {
+            printLog(logs.errorLogs.INVALID_API_KEY, MessageType.ERROR, logLevel);
+            throw new SkyflowError(SKYFLOW_ERROR_CODE.INVALID_API_KEY_WITH_ID, [type, typeId, id]);
+        }
     }
-
 };
 
 export const validateVaultConfig = (vaultConfig: VaultConfig, logLevel: LogLevel = LogLevel.ERROR) => {
@@ -225,41 +257,73 @@ export const validateUpdateVaultConfig = (vaultConfig: VaultConfig, logLevel: Lo
 };
 
 export const validateSkyflowCredentials = (credentials: Credentials, logLevel: LogLevel = LogLevel.ERROR) => {
-    const { token, path, credentialsString, apiKey } = credentials;
-
-    // Count how many of the fields are defined
-    const definedFields = [token, path, credentialsString, apiKey].filter(Boolean).length;
-
-    // If none are present
-    if (definedFields === 0) {
+    if (!credentials) {
         throw new SkyflowError(SKYFLOW_ERROR_CODE.CREDENTIALS_WITH_NO_VALID_KEY);
     }
 
-    // If more than one is present
-    if (definedFields > 1) {
+    const isTokenCred = 'token' in credentials;
+    const isPathCred = 'path' in credentials;
+    const isStringCred = 'credentialsString' in credentials;
+    const isApiKeyCred = 'apiKey' in credentials;
+
+    // Check if exactly one credential type is provided
+    const definedTypes = [isTokenCred, isPathCred, isStringCred, isApiKeyCred].filter(Boolean).length;
+
+    if (definedTypes === 0) {
+        throw new SkyflowError(SKYFLOW_ERROR_CODE.CREDENTIALS_WITH_NO_VALID_KEY);
+    }
+
+    if (definedTypes > 1) {
         throw new SkyflowError(SKYFLOW_ERROR_CODE.MULTIPLE_CREDENTIALS_PASSED);
     }
 
-    if (credentials?.token && (typeof credentials?.token !== 'string' || isExpired(credentials?.token))) {
-        printLog(logs.errorLogs.EMPTY_TOKEN_VALUE, MessageType.ERROR, logLevel);
-        throw new SkyflowError(SKYFLOW_ERROR_CODE.INVALID_BEARER_TOKEN);
+    // Validate TokenCredentials
+    if (isTokenCred) {
+        const tokenCred = credentials as TokenCredentials;
+        if (typeof tokenCred.token !== 'string' || isExpired(tokenCred.token)) {
+            printLog(logs.errorLogs.EMPTY_TOKEN_VALUE, MessageType.ERROR, logLevel);
+            throw new SkyflowError(SKYFLOW_ERROR_CODE.INVALID_BEARER_TOKEN);
+        }
     }
 
-    if (credentials?.credentialsString && (typeof credentials?.credentialsString !== 'string' || !isValidCredentialsString(credentials?.credentialsString))) {
-        printLog(logs.errorLogs.EMPTY_CREDENTIALS_STRING, MessageType.ERROR, logLevel);
-        throw new SkyflowError(SKYFLOW_ERROR_CODE.INVALID_PARSED_CREDENTIALS_STRING);
+    // Validate PathCredentials
+    if (isPathCred) {
+        const pathCred = credentials as PathCredentials;
+        if (typeof pathCred.path !== 'string' || !isValidPath(pathCred.path)) {
+            printLog(logs.errorLogs.EMPTY_CREDENTIALS_PATH, MessageType.ERROR, logLevel);
+            throw new SkyflowError(SKYFLOW_ERROR_CODE.INVALID_FILE_PATH);
+        }
+        if (pathCred.roles !== undefined && !Array.isArray(pathCred.roles)) {
+            throw new SkyflowError(SKYFLOW_ERROR_CODE.INVALID_ROLES_KEY_TYPE);
+        }
+        if (pathCred.context !== undefined && typeof pathCred.context !== 'string') {
+            throw new SkyflowError(SKYFLOW_ERROR_CODE.INVALID_CONTEXT);
+        }
     }
 
-    if (credentials?.apiKey && (typeof credentials?.apiKey !== 'string' || !isValidAPIKey(credentials?.apiKey))) {
-        printLog(logs.errorLogs.INVALID_API_KEY, MessageType.ERROR, logLevel);
-        throw new SkyflowError(SKYFLOW_ERROR_CODE.INVALID_API_KEY);
+    // Validate StringCredentials
+    if (isStringCred) {
+        const stringCred = credentials as StringCredentials;
+        if (typeof stringCred.credentialsString !== 'string' || !isValidCredentialsString(stringCred.credentialsString)) {
+            printLog(logs.errorLogs.EMPTY_CREDENTIALS_STRING, MessageType.ERROR, logLevel);
+            throw new SkyflowError(SKYFLOW_ERROR_CODE.INVALID_PARSED_CREDENTIALS_STRING);
+        }
+        if (stringCred.roles !== undefined && !Array.isArray(stringCred.roles)) {
+            throw new SkyflowError(SKYFLOW_ERROR_CODE.INVALID_ROLES_KEY_TYPE);
+        }
+        if (stringCred.context !== undefined && typeof stringCred.context !== 'string') {
+            throw new SkyflowError(SKYFLOW_ERROR_CODE.INVALID_CONTEXT);
+        }
     }
 
-    if (credentials?.path && (typeof credentials?.path !== 'string' || !isValidPath(credentials?.path))) {
-        printLog(logs.errorLogs.EMPTY_CREDENTIALS_PATH, MessageType.ERROR, logLevel);
-        throw new SkyflowError(SKYFLOW_ERROR_CODE.INVALID_FILE_PATH);
+    // Validate ApiKeyCredentials
+    if (isApiKeyCred) {
+        const apiKeyCred = credentials as ApiKeyCredentials;
+        if (typeof apiKeyCred.apiKey !== 'string' || !isValidAPIKey(apiKeyCred.apiKey)) {
+            printLog(logs.errorLogs.INVALID_API_KEY, MessageType.ERROR, logLevel);
+            throw new SkyflowError(SKYFLOW_ERROR_CODE.INVALID_API_KEY);
+        }
     }
-
 };
 
 export const validateConnectionConfig = (connectionConfig: ConnectionConfig, logLevel: LogLevel = LogLevel.ERROR) => {

--- a/src/vault/config/credentials/index.ts
+++ b/src/vault/config/credentials/index.ts
@@ -1,11 +1,27 @@
+export type Credentials = 
+  | TokenCredentials 
+  | PathCredentials 
+  | StringCredentials 
+  | ApiKeyCredentials;
 
-interface Credentials {
-    token?: string;
-    path?: string;
-    credentialsString?: string;
-    apiKey?: string;
-    roles?: Array<string>;
-    context?: string;
+export interface TokenCredentials {
+  token: string;
+}
+
+export interface PathCredentials {
+  path: string;
+  roles?: Array<string>;
+  context?: string;
+}
+
+export interface StringCredentials {
+  credentialsString: string;
+  roles?: Array<string>;
+  context?: string;
+}
+
+export interface ApiKeyCredentials {
+  apiKey: string;
 }
 
 export default Credentials;

--- a/test/vault/utils/utils.test.js
+++ b/test/vault/utils/utils.test.js
@@ -388,7 +388,7 @@ describe('printLog', () => {
 describe('getToken', () => {
     const logLevel = LogLevel.INFO;
 
-    test('should generate token from credentialsString', async () => {
+    test('should generate token from StringCredentials', async () => {
         const credentials = {
             credentialsString: 'someCredentials',
             roles: ['role1', 'role2'],
@@ -397,7 +397,7 @@ describe('getToken', () => {
         const mockToken = { accessToken: 'token123' };
 
         generateBearerTokenFromCreds.mockResolvedValue(mockToken);
-        console.log(getToken)
+
         const result = await getToken(credentials, logLevel);
 
         expect(result).toEqual(mockToken);
@@ -408,7 +408,7 @@ describe('getToken', () => {
         });
     });
 
-    test('should generate token from path', async () => {
+    test('should generate token from PathCredentials', async () => {
         const credentials = {
             path: '/some/path',
             roles: ['role1'],
@@ -428,6 +428,25 @@ describe('getToken', () => {
         });
     });
 
+    test('should throw error for TokenCredentials', async () => {
+        const credentials = {
+            token: 'someToken'
+        };
+
+        await expect(getToken(credentials, logLevel))
+            .rejects
+            .toThrow();
+    });
+
+    test('should throw error for ApiKeyCredentials', async () => {
+        const credentials = {
+            apiKey: 'sky-api-key'
+        };
+
+        await expect(getToken(credentials, logLevel))
+            .rejects
+            .toThrow();
+    });
 });
 
 describe('getBearerToken', () => {
@@ -435,71 +454,72 @@ describe('getBearerToken', () => {
 
     beforeEach(() => {
         jest.clearAllMocks();
-        process.env.SKYFLOW_CREDENTIALS = undefined; // Reset environment variable before each test
+        process.env.SKYFLOW_CREDENTIALS = undefined;
     });
 
-    test('should use environment variable if no credentials passed but environment variable exists', async () => {
-        try {
-            process.env.SKYFLOW_CREDENTIALS = 'someEnvCredentials';
-            const mockToken = { accessToken: 'token456' };
-            const getToken = jest.fn();
-            getToken.mockResolvedValue(mockToken);
-
-            const result = await getBearerToken(undefined, logLevel);
-
-            expect(getToken).toHaveBeenCalledWith({
-                credentialsString: 'someEnvCredentials'
-            }, logLevel);
-            expect(result).toEqual({ type: AuthType.TOKEN, key: mockToken.accessToken });
-        } catch (err) {
-            expect(err).toBeDefined();
-        }
+    test('should throw error if no credentials and no env variable', async () => {
+        await expect(getBearerToken(undefined, logLevel))
+            .rejects
+            .toThrow();
     });
 
-    test('should return API key immediately if apiKey is provided in credentials', async () => {
-        try {
-            const credentials = { apiKey: 'someApiKey' };
+    test('should use environment variable when credentials not provided', async () => {
+        process.env.SKYFLOW_CREDENTIALS = 'someEnvCredentials';
+        const mockToken = { accessToken: 'token456' };
+        generateBearerTokenFromCreds.mockResolvedValue(mockToken);
 
-            const result = await getBearerToken(credentials, logLevel);
+        const result = await getBearerToken(undefined, logLevel);
 
-            expect(result).toEqual({ type: AuthType.API_KEY, key: 'someApiKey' });
-            expect(getToken).not.toHaveBeenCalled();
-        } catch (err) {
-            expect(err).toBeDefined();
-        }
+        expect(result).toEqual({"key": "token456", "type": "TOKEN"});
     });
 
-    test('should return token immediately after validating token if token is provided', async () => {
-        try {
-            const credentials = { token: 'someToken' };
-            validateToken.mockReturnValue('validatedToken');
+    test('should handle ApiKeyCredentials correctly', async () => {
+        const credentials = {
+            apiKey: 'sky-valid-api-key'
+        };
 
-            const result = await getBearerToken(credentials, logLevel);
+        const result = await getBearerToken(credentials, logLevel);
 
-            expect(validateToken).toHaveBeenCalledWith('someToken');
-            expect(result).toEqual({ type: AuthType.TOKEN, key: 'validatedToken' });
-            expect(getToken).not.toHaveBeenCalled();
-        } catch (err) {
-            expect(err).toBeDefined();
-        }
+        expect(result).toEqual({"key": "sky-valid-api-key", "type": "API_KEY"});
     });
 
-    test('should generate token if valid credentials are provided for token generation', async () => {
-        try {
-            const credentials = { credentialsString: 'someCreds' };
-            const mockToken = { accessToken: 'generatedToken' };
-            const getToken = jest.fn();
-            getToken.mockResolvedValue(mockToken);
+    test('should handle TokenCredentials correctly', async () => {
+        const credentials = {
+            token: 'validToken'
+        };
+        jwt_decode.mockReturnValue({ exp: Date.now() / 1000 + 3600 }); // Valid for 1 hour
 
-            const result = await getBearerToken(credentials, logLevel);
+        const result = await getBearerToken(credentials, logLevel);
 
-            expect(printLog).toHaveBeenCalledWith(logs.infoLogs.BEARER_TOKEN_LISTENER, 'LOG', logLevel);
-            expect(getToken).toHaveBeenCalledWith(credentials, logLevel);
-            expect(result).toEqual({ type: AuthType.TOKEN, key: mockToken.accessToken });
-        } catch (err) {
-            expect(err).toBeDefined();
-        }
+        expect(result).toEqual({"key": "validToken", "type": "TOKEN"});
     });
 
+    test('should handle StringCredentials correctly', async () => {
+        const credentials = {
+            credentialsString: 'validCredString',
+            roles: ['role1'],
+            context: 'test'
+        };
+        const mockToken = { accessToken: 'generatedToken' };
+        generateBearerTokenFromCreds.mockResolvedValue(mockToken);
+
+        const result = await getBearerToken(credentials, logLevel);
+
+        expect(result).toEqual({"key": "generatedToken", "type": "TOKEN"});
+    });
+
+    test('should handle PathCredentials correctly', async () => {
+        const credentials = {
+            path: '/valid/path',
+            roles: ['role1'],
+            context: 'test'
+        };
+        const mockToken = { accessToken: 'generatedToken' };
+        generateBearerToken.mockResolvedValue(mockToken);
+
+        const result = await getBearerToken(credentials, logLevel);
+
+        expect(result).toEqual({"key": "generatedToken", "type": "TOKEN"});
+    });
 });
 


### PR DESCRIPTION
**Why**

- To enhance clarity in credential configuration.

- To enable stricter compile-time validation for credential setups.

**Outcome**

- Credential configurations will be clearer and more explicit.