### PR TITLE
SK-2116: update masking method enum to support blackbox masking method

### DIFF
--- a/src/ _generated_/rest/api/resources/files/types/DeidentifyImageRequestMaskingMethod.ts
+++ b/src/ _generated_/rest/api/resources/files/types/DeidentifyImageRequestMaskingMethod.ts
@@ -5,8 +5,8 @@
 /**
  * Method to mask the entities in the image.
  */
-export type DeidentifyImageRequestMaskingMethod = "blackout" | "blur";
+export type DeidentifyImageRequestMaskingMethod = "blackbox" | "blur";
 export const DeidentifyImageRequestMaskingMethod = {
-    Blackout: "blackout",
+    Blackbox: "blackbox",
     Blur: "blur",
 } as const;

--- a/src/ _generated_/rest/api/types/DeidentifyStatusResponseOutputType.ts
+++ b/src/ _generated_/rest/api/types/DeidentifyStatusResponseOutputType.ts
@@ -5,8 +5,9 @@
 /**
  * How the output file is specified.
  */
-export type DeidentifyStatusResponseOutputType = "base64" | "efs_path";
+export type DeidentifyStatusResponseOutputType = "BASE64" | "EFS_PATH" | "UNKNOWN";
 export const DeidentifyStatusResponseOutputType = {
-    Base64: "base64",
-    EfsPath: "efs_path",
+    Base64: "BASE64",
+    EfsPath: "EFS_PATH",
+    Unknown: "UNKNOWN",
 } as const;

--- a/src/ _generated_/rest/api/types/DeidentifyStatusResponseStatus.ts
+++ b/src/ _generated_/rest/api/types/DeidentifyStatusResponseStatus.ts
@@ -5,9 +5,9 @@
 /**
  * Status of the detect run.
  */
-export type DeidentifyStatusResponseStatus = "failed" | "in_progress" | "success";
+export type DeidentifyStatusResponseStatus = "FAILED" | "IN_PROGRESS" | "SUCCESS";
 export const DeidentifyStatusResponseStatus = {
-    Failed: "failed",
-    InProgress: "in_progress",
-    Success: "success",
+    Failed: "FAILED",
+    InProgress: "IN_PROGRESS",
+    Success: "SUCCESS",
 } as const;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -131,7 +131,7 @@ export enum DetectOutputTranscription {
 }
 
 export enum MaskingMethod{
-    Blackout= "blackout",
+    Blackbox= "blackbox",
     Blur= "blur",
 }
 

--- a/test/vault/utils/utils.test.js
+++ b/test/vault/utils/utils.test.js
@@ -451,16 +451,22 @@ describe('getToken', () => {
 
 describe('getBearerToken', () => {
     const logLevel = LogLevel.INFO;
+    const originalEnv = process.env;
 
     beforeEach(() => {
         jest.clearAllMocks();
-        process.env.SKYFLOW_CREDENTIALS = undefined;
+        process.env = { ...originalEnv };
+        delete process.env.SKYFLOW_CREDENTIALS;
+    });
+
+    afterEach(() => {
+        process.env = originalEnv;
     });
 
     test('should throw error if no credentials and no env variable', async () => {
         await expect(getBearerToken(undefined, logLevel))
             .rejects
-            .toThrow();
+            .toThrow(errorMessages.CREDENTIALS_REQUIRED);
     });
 
     test('should use environment variable when credentials not provided', async () => {


### PR DESCRIPTION
This PR updates the `MaskingMethod` for `deidentify image` to support `BLACKBOX` masking.

## Why
- Python SDK didn't support `BLACKBOX` masking method.

## Goal
- Added `BLACKBOX` enum in the Masking method to support while doing `deidentify image`.

## Testing
- Manually tested the changes.