### PR TITLE
SK-2119: fix type gaps in failure response handling

### DIFF
--- a/src/vault/controller/detect/index.ts
+++ b/src/vault/controller/detect/index.ts
@@ -24,6 +24,7 @@ import SkyflowError from "../../../error";
 import SKYFLOW_ERROR_CODE from "../../../error/codes";
 import GetDetectRunRequest from "../../model/request/get-detect-run";
 import Transformations from "../../model/options/deidentify-text/transformations";
+import { SkyflowAllError } from "../../types";
 
 class DetectController {
 
@@ -396,7 +397,7 @@ class DetectController {
                                 break;
 
                         }
-                    }).catch((error: any) => {
+                    }).catch((error: SkyflowAllError) => {
                         printLog(logs.errorLogs[`${requestType}_REQUEST_REJECTED`], MessageType.ERROR, this.client.getLogLevel());
                         this.client.failureResponse(error).catch((err) => reject(err))
                     });

--- a/src/vault/types/index.ts
+++ b/src/vault/types/index.ts
@@ -6,6 +6,7 @@ import VaultController from "../controller/vault";
 import ConnectionController from "../controller/connections";
 import VaultClient from "../client";
 import DetectController from "../controller/detect";
+import SkyflowError from "../../error";
 
 export interface SkyflowConfig {
     vaultConfigs?: VaultConfig[];
@@ -77,3 +78,46 @@ export interface DetokenizeData {
     token: string;
     redactionType?: RedactionType;
 }
+
+export interface SkyflowApiErrorNewFormat {
+  rawResponse: {
+    headers: { get(key: string): string | undefined };
+  };
+  body: {
+    error: {
+      message: string;
+      http_code?: number;
+      grpc_code?: number | string;
+      details?: any[];
+    };
+  };
+  statusCode?: number;
+  message?: string;
+}
+
+export interface SkyflowApiErrorLegacyBody {
+  error: {
+    message: string;
+    http_code?: number;
+    grpc_code?: number | string;
+    details?: any[];
+  };
+}
+
+export interface SkyflowApiErrorLegacy {
+  headers: { get(key: string): string | undefined };
+  body?: SkyflowApiErrorLegacyBody;
+  statusCode?: number;
+  message?: string;
+}
+
+export type SkyflowAllError =
+  | SkyflowApiErrorNewFormat
+  | SkyflowApiErrorLegacy
+  | SkyflowError
+  | Error;
+
+export type SkyflowErrorData =
+  | SkyflowApiErrorNewFormat['body']['error']
+  | SkyflowApiErrorLegacyBody['error']
+  | undefined;


### PR DESCRIPTION
**Why**

- There is use of Object or any at few places in node sdk which can be replaced with a specific types or interfaces to align with typescript best practices. 

**Outcome**

- Use proper types or interfaces wherever possible and avoid usage of object or any