### PR TITLE
SK-2101 fix content type key in invoke connection

### DIFF
--- a/samples/vault-api/invoke-connection.ts
+++ b/samples/vault-api/invoke-connection.ts
@@ -61,7 +61,7 @@ async function invokeSkyflowConnection() {
         };
 
         const requestHeaders: Record<string, string> = {
-            'content-type': 'application/json'
+            'Content-Type': 'application/json'
         };
 
         const requestMethod: RequestMethod = RequestMethod.POST;


### PR DESCRIPTION
## Why
- The Content-Type key in the invoke connection sample is using incorrect casing

## Goal
- The Content-Type key in the invoke connection sample should have correct casing