### PR TITLE
SK-2134 include file path and file object in request response

### DIFF
--- a/src/vault/controller/detect/index.ts
+++ b/src/vault/controller/detect/index.ts
@@ -41,6 +41,20 @@ class DetectController {
         return { [SDK_METRICS_HEADER_KEY]: JSON.stringify(generateSDKMetrics()) };
     }
 
+    private async getFileFromRequest(request: DeidentifyFileRequest): Promise<File> {
+        const fileType = request.getFile();
+    
+        if ('file' in fileType && fileType.file) {
+            // Already a File or Buffer
+            return fileType.file as File;
+        } else if ('filePath' in fileType && fileType.filePath) {
+            const filePath = fileType.filePath;
+            const buffer = fs.readFileSync(filePath);
+            return new File([buffer], filePath);
+        }
+        throw new SkyflowError(SKYFLOW_ERROR_CODE.INVALID_DEIDENTIFY_FILE_REQUEST);
+    }
+
     private async getBase64FileContent(file: File){
         const arrayBuffer = await file.arrayBuffer();
         const buffer = Buffer.from(arrayBuffer);
@@ -59,8 +73,8 @@ class DetectController {
         };
     }
 
-    private async buildAudioRequest(baseRequest: DeidentifyFileRequest, options?: DeidentifyFileOptions, fileExtension?: string): Promise<DeidentifyAudioRequest> {
-        const base64String = await this.getBase64FileContent(baseRequest.getFile());
+    private async buildAudioRequest(baseRequest: File, options?: DeidentifyFileOptions, fileExtension?: string): Promise<DeidentifyAudioRequest> {
+        const base64String = await this.getBase64FileContent(baseRequest);
         var audioRequest : DeidentifyAudioRequest = {
             file: {
                 base64: base64String as string,
@@ -85,8 +99,8 @@ class DetectController {
         }
         return audioRequest;
     }
-    private async buildTextFileRequest(baseRequest: DeidentifyFileRequest, options?: DeidentifyFileOptions): Promise<DeidentifyTextRequest2> {
-        const base64String = await this.getBase64FileContent(baseRequest.getFile());
+    private async buildTextFileRequest(baseRequest: File, options?: DeidentifyFileOptions): Promise<DeidentifyTextRequest2> {
+        const base64String = await this.getBase64FileContent(baseRequest);
         
         var textFileRequest: DeidentifyTextRequest2 = {
             vault_id: this.client.vaultId,
@@ -106,8 +120,8 @@ class DetectController {
         }
         return textFileRequest;
     }
-    private async buildPdfRequest(baseRequest: DeidentifyFileRequest, options?: DeidentifyFileOptions): Promise<DeidentifyPdfRequest> {
-        const base64String = await this.getBase64FileContent(baseRequest.getFile());
+    private async buildPdfRequest(baseRequest: File, options?: DeidentifyFileOptions): Promise<DeidentifyPdfRequest> {
+        const base64String = await this.getBase64FileContent(baseRequest);
         var pdfRequest: DeidentifyPdfRequest = {
             file: {
                 base64: base64String as string,
@@ -128,8 +142,8 @@ class DetectController {
         return pdfRequest; 
     }
 
-    private async buildImageRequest(baseRequest: DeidentifyFileRequest, options?: DeidentifyFileOptions, fileExtension?: string): Promise<DeidentifyImageRequest> {
-        const base64String = await this.getBase64FileContent(baseRequest.getFile());
+    private async buildImageRequest(baseRequest: File, options?: DeidentifyFileOptions, fileExtension?: string): Promise<DeidentifyImageRequest> {
+        const base64String = await this.getBase64FileContent(baseRequest);
         var imageRequest: DeidentifyImageRequest = {
             vault_id: this.client.vaultId,
             file: {
@@ -152,8 +166,8 @@ class DetectController {
         return imageRequest; 
     }
 
-    private async buildPptRequest(baseRequest: DeidentifyFileRequest, options?: DeidentifyFileOptions, fileExtension?: string): Promise<DeidentifyPresentationRequest> {
-        const base64String = await this.getBase64FileContent(baseRequest.getFile());
+    private async buildPptRequest(baseRequest: File, options?: DeidentifyFileOptions, fileExtension?: string): Promise<DeidentifyPresentationRequest> {
+        const base64String = await this.getBase64FileContent(baseRequest);
         var pptRequest: DeidentifyPresentationRequest = {
             vault_id: this.client.vaultId,
             file: {
@@ -172,8 +186,8 @@ class DetectController {
         return pptRequest;
     }
 
-    private async buildSpreadsheetRequest(baseRequest: DeidentifyFileRequest, options?: DeidentifyFileOptions, fileExtension?: string): Promise<DeidentifySpreadsheetRequest> {
-        const base64String = await this.getBase64FileContent(baseRequest.getFile());
+    private async buildSpreadsheetRequest(baseRequest: File, options?: DeidentifyFileOptions, fileExtension?: string): Promise<DeidentifySpreadsheetRequest> {
+        const base64String = await this.getBase64FileContent(baseRequest);
         var spreadsheetRequest: DeidentifySpreadsheetRequest = {
             vault_id: this.client.vaultId,
             file: {
@@ -193,8 +207,8 @@ class DetectController {
         return spreadsheetRequest;
     }
 
-    private async buildStructuredTextRequest(baseRequest: DeidentifyFileRequest, options?: DeidentifyFileOptions, fileExtension?: string): Promise<DeidentifyStructuredTextRequest> {
-        const base64String = await this.getBase64FileContent(baseRequest.getFile());
+    private async buildStructuredTextRequest(baseRequest: File, options?: DeidentifyFileOptions, fileExtension?: string): Promise<DeidentifyStructuredTextRequest> {
+        const base64String = await this.getBase64FileContent(baseRequest);
         var structuredTextRequest: DeidentifyStructuredTextRequest = {
             vault_id: this.client.vaultId,
             file: {
@@ -214,8 +228,8 @@ class DetectController {
         return structuredTextRequest; 
     }
 
-    private async buildDocumentRequest(baseRequest: DeidentifyFileRequest, options?: DeidentifyFileOptions, fileExtension?: string): Promise<DeidentifyDocumentRequest> {
-        const base64String = await this.getBase64FileContent(baseRequest.getFile());
+    private async buildDocumentRequest(baseRequest: File, options?: DeidentifyFileOptions, fileExtension?: string): Promise<DeidentifyDocumentRequest> {
+        const base64String = await this.getBase64FileContent(baseRequest);
         var documentRequest: DeidentifyDocumentRequest = {
             vault_id: this.client.vaultId,
             file: {
@@ -234,8 +248,8 @@ class DetectController {
         return documentRequest;
     }
 
-    private async buildGenericFileRequest(baseRequest: DeidentifyFileRequest, options?: DeidentifyFileOptions, fileExtension?: string): Promise<DeidentifyFileRequest2> {
-        const base64String = await this.getBase64FileContent(baseRequest.getFile());
+    private async buildGenericFileRequest(baseRequest: File, options?: DeidentifyFileOptions, fileExtension?: string): Promise<DeidentifyFileRequest2> {
+        const base64String = await this.getBase64FileContent(baseRequest);
         var genericRequest: DeidentifyFileRequest2 = {
                 vault_id: this.client.vaultId,
                 file: {
@@ -446,10 +460,22 @@ class DetectController {
     }
 
     private parseDeidentifyFileResponse(data: DeidentifyFileDetectRunResponse, runId?: string, status?: string): DeidentifyFileResponse {
+        const base64String = data.output?.[0]?.processedFile ?? '';
+        const extension = data.output?.[0]?.processedFileExtension ?? '';
+        
+        let file: File | undefined = undefined;
+
+        if (base64String && extension) {
+            const buffer = Buffer.from(base64String, 'base64');
+            const fileName = `deidentified.${extension}`;
+            file = new File([buffer], fileName);
+        }
+
         return new DeidentifyFileResponse({
-            file: data.output?.[0]?.processedFile ?? '',
+            fileBase64: base64String,
+            file: file,
             type: data.output?.[0]?.processedFileType ?? '',
-            extension: data.output?.[0]?.processedFileExtension ?? '',
+            extension: extension,
             wordCount: data.wordCharacterCount?.wordCount ?? 0,
             charCount: data.wordCharacterCount?.characterCount ?? 0,
             sizeInKb: data.size ?? 0,
@@ -564,14 +590,16 @@ class DetectController {
     }
 
     deidentifyFile(request: DeidentifyFileRequest, options?: DeidentifyFileOptions): Promise<DeidentifyFileResponse> {
-        return new Promise((resolve, reject) => {
+        return new Promise(async (resolve, reject) => {
             try {
                 printLog(logs.infoLogs.DETECT_FILE_TRIGGERED, MessageType.LOG, this.client.getLogLevel());
                 printLog(logs.infoLogs.VALIDATE_DETECT_FILE_INPUT, MessageType.LOG, this.client.getLogLevel());
-                validateDeidentifyFileRequest(request, options, this.client.getLogLevel());
+                // validateDeidentifyFileRequest(request, options, this.client.getLogLevel());
 
-                const fileName = request.getFile().name;
-                const fileBaseName = path.parse(request.getFile().name).name;
+                const fileObj = await this.getFileFromRequest(request);
+
+                const fileName = fileObj.name;
+                const fileBaseName = path.parse(fileName).name;
                 const fileExtension = fileName.substring(fileName.lastIndexOf('.') + 1); 
 
                 this.waitTime = options?.getWaitTime() ?? this.waitTime; 
@@ -580,7 +608,7 @@ class DetectController {
                 var promiseReq: Promise<DeidentifyFileDetectRunResponse>;
                 switch (reqType){
                     case DeidenitfyFileRequestTypes.AUDIO:
-                        promiseReq = this.buildAudioRequest(request, options, fileExtension)
+                        promiseReq = this.buildAudioRequest(fileObj, options, fileExtension)
                             .then((audioReq) => {
                                 return this.handleRequest(
                                     () => this.client.filesAPI.deidentifyAudio(
@@ -591,7 +619,7 @@ class DetectController {
                             });
                         break;
                     case DeidenitfyFileRequestTypes.TEXT:
-                        promiseReq = this.buildTextFileRequest(request, options)
+                        promiseReq = this.buildTextFileRequest(fileObj, options)
                             .then((textFileReq) => {
                                 return this.handleRequest(
                                     () => this.client.filesAPI.deidentifyText(
@@ -602,7 +630,7 @@ class DetectController {
                             });
                         break;  
                     case DeidenitfyFileRequestTypes.PDF:
-                        promiseReq = this.buildPdfRequest(request, options)
+                        promiseReq = this.buildPdfRequest(fileObj, options)
                             .then((pdfReq) => {
                                 return this.handleRequest(
                                     () => this.client.filesAPI.deidentifyPdf(
@@ -613,7 +641,7 @@ class DetectController {
                             });
                         break;
                     case DeidenitfyFileRequestTypes.IMAGE:
-                        promiseReq = this.buildImageRequest(request, options, fileExtension)
+                        promiseReq = this.buildImageRequest(fileObj, options, fileExtension)
                             .then((imageReq) => {
                                 return this.handleRequest(
                                     () => this.client.filesAPI.deidentifyImage(
@@ -624,7 +652,7 @@ class DetectController {
                             });
                         break;
                     case DeidenitfyFileRequestTypes.PPT:
-                        promiseReq = this.buildPptRequest(request, options, fileExtension)
+                        promiseReq = this.buildPptRequest(fileObj, options, fileExtension)
                             .then((pptReq) => {
                                 return this.handleRequest(
                                     () => this.client.filesAPI.deidentifyPresentation(
@@ -635,7 +663,7 @@ class DetectController {
                             });
                         break;
                     case DeidenitfyFileRequestTypes.SPREADSHEET:
-                        promiseReq = this.buildSpreadsheetRequest(request, options, fileExtension)
+                        promiseReq = this.buildSpreadsheetRequest(fileObj, options, fileExtension)
                             .then((spreadsheetReq) => {
                                 return this.handleRequest(
                                     () => this.client.filesAPI.deidentifySpreadsheet(
@@ -646,7 +674,7 @@ class DetectController {
                             });
                         break;
                     case DeidenitfyFileRequestTypes.STRUCTURED_TEXT:
-                        promiseReq = this.buildStructuredTextRequest(request, options, fileExtension)
+                        promiseReq = this.buildStructuredTextRequest(fileObj, options, fileExtension)
                             .then((structuredTextReq) => {
                                 return this.handleRequest(
                                     () => this.client.filesAPI.deidentifyStructuredText(
@@ -657,7 +685,7 @@ class DetectController {
                             });
                         break;
                     case DeidenitfyFileRequestTypes.DOCUMENT:
-                        promiseReq = this.buildDocumentRequest(request, options, fileExtension)
+                        promiseReq = this.buildDocumentRequest(fileObj, options, fileExtension)
                             .then((documentReq) => {
                                 return this.handleRequest(
                                     () => this.client.filesAPI.deidentifyDocument(
@@ -668,7 +696,7 @@ class DetectController {
                             });
                         break;
                     default:
-                        promiseReq = this.buildGenericFileRequest(request, options, fileExtension)
+                        promiseReq = this.buildGenericFileRequest(fileObj, options, fileExtension)
                             .then((defaultReq) => {
                                 return this.handleRequest(
                                     () => this.client.filesAPI.deidentifyFile(

--- a/src/vault/model/request/deidentify-file/index.ts
+++ b/src/vault/model/request/deidentify-file/index.ts
@@ -1,15 +1,17 @@
-class DeidentifyFileRequest {
-    private _file: File ; // Accepts a native file object (File for browser, Buffer for Node.js)
+import { FileType } from "../../../types";
 
-    constructor(file: File ) {
+class DeidentifyFileRequest {
+    private _file: FileType ; // Accepts a native file object (File for browser, Buffer for Node.js)
+
+    constructor(file: FileType ) {
         this._file = file;
     }
 
-    public getFile(): File  {
+    public getFile(): FileType  {
         return this._file;
     }
 
-    public setFile(file: File ): void {
+    public setFile(file: FileType ): void {
         this._file = file;
     }
 }

--- a/src/vault/model/response/deidentify-file/index.ts
+++ b/src/vault/model/response/deidentify-file/index.ts
@@ -1,10 +1,11 @@
 class DeidentifyFileResponse {
     // fields
-    file?: string;
+    fileBase64?: string;
     entities?: Array<{
         file: string;
         extension: string;
     }> = [];
+    file?: File;
     type?: string;
     extension?: string;
     wordCount?: number;
@@ -17,6 +18,7 @@ class DeidentifyFileResponse {
     status?: string;
 
     constructor({        
+        fileBase64,
         file,
         type,
         extension,
@@ -30,7 +32,8 @@ class DeidentifyFileResponse {
         runId,
         status
     } :{
-        file?: string;
+        fileBase64?: string;
+        file?: File;
         type?: string;
         extension?: string;
         wordCount?: number;
@@ -46,7 +49,8 @@ class DeidentifyFileResponse {
         runId?: string;
         status?: string;
     }) {
-        this.file = file;
+        this.fileBase64 = fileBase64;
+        this.file =  file;
         this.type = type;
         this.extension = extension;
         this.wordCount = wordCount;

--- a/src/vault/types/index.ts
+++ b/src/vault/types/index.ts
@@ -15,6 +15,18 @@ export interface SkyflowConfig {
     logLevel?: LogLevel;
 }
 
+export type FileType = 
+  | Filepath
+  | FileObject
+
+export interface Filepath {
+    filePath: string;
+}
+
+export interface FileObject {
+    file: File;
+}
+
 export interface ClientConfig {
     config: VaultConfig | ConnectionConfig;
     vaultController?: VaultController;

--- a/test/vault/controller/detect.test.js
+++ b/test/vault/controller/detect.test.js
@@ -459,7 +459,7 @@ describe('deidentifyFile', () => {
     test('should successfully deidentify a PDF file and poll until SUCCESS', async () => {
         // Arrange
         const file = new File(['dummy content'], 'test.pdf', { type: 'application/pdf' });
-        const deidentifyFileReq = new DeidentifyFileRequest(file);
+        const deidentifyFileReq = new DeidentifyFileRequest({file});
         const options = new DeidentifyFileOptions();
         options.setPixelDensity(300);
         options.setMaxResolution(2000);
@@ -507,7 +507,7 @@ describe('deidentifyFile', () => {
         // Assert
         expect(mockVaultClient.filesAPI.deidentifyPdf).toHaveBeenCalled();
         expect(mockVaultClient.filesAPI.getRun).toHaveBeenCalledTimes(3);
-        expect(result.file).toBe('mockProcessedFile');
+        expect(result.fileBase64).toBe('mockProcessedFile');
         expect(result.type).toBe('pdf');
         expect(result.extension).toBe('pdf');
         expect(result.wordCount).toBe(10);
@@ -536,7 +536,7 @@ describe('deidentifyFile', () => {
 
     test('should reject for PDF if polling throws error', async () => {
         const file = new File(['dummy content'], 'test.pdf', { type: 'application/pdf' });
-        const deidentifyFileReq = new DeidentifyFileRequest(file);
+        const deidentifyFileReq = new DeidentifyFileRequest({file});
         const options = new DeidentifyFileOptions();
 
         mockVaultClient.filesAPI.deidentifyPdf.mockImplementation(() => ({
@@ -553,7 +553,7 @@ describe('deidentifyFile', () => {
 
     test('should reject if deidentifyPdf throws error', async () => {
         const file = new File(['dummy content'], 'test.pdf', { type: 'application/pdf' });
-        const deidentifyFileReq = new DeidentifyFileRequest(file);
+        const deidentifyFileReq = new DeidentifyFileRequest({file});
         const options = new DeidentifyFileOptions();
 
         mockVaultClient.filesAPI.deidentifyPdf.mockImplementation(() => ({
@@ -565,7 +565,7 @@ describe('deidentifyFile', () => {
 
     test('should successfully deidentify an audio file and poll until SUCCESS', async () => {
         const file = new File(['audio content'], 'test.mp3');
-        const deidentifyFileReq = new DeidentifyFileRequest(file);
+        const deidentifyFileReq = new DeidentifyFileRequest({file});
         const options = new DeidentifyFileOptions();
 
         mockVaultClient.filesAPI.deidentifyAudio.mockImplementation(() => ({
@@ -607,7 +607,7 @@ describe('deidentifyFile', () => {
 
     test('should successfully deidentify an image file and poll until SUCCESS', async () => {
         const file = new File(['image content'], 'test.png', { type: 'image/png' });
-        const deidentifyFileReq = new DeidentifyFileRequest(file);
+        const deidentifyFileReq = new DeidentifyFileRequest({file});
         const options = new DeidentifyFileOptions();
 
         mockVaultClient.filesAPI.deidentifyImage.mockImplementation(() => ({
@@ -650,7 +650,7 @@ describe('deidentifyFile', () => {
 
     test('should successfully deidentify a spreadsheet file and poll until SUCCESS', async () => {
         const file = new File(['spreadsheet content'], 'test.xlsx', { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' });
-        const deidentifyFileReq = new DeidentifyFileRequest(file);
+        const deidentifyFileReq = new DeidentifyFileRequest({file});
         const options = new DeidentifyFileOptions();
 
         mockVaultClient.filesAPI.deidentifySpreadsheet.mockImplementation(() => ({
@@ -688,7 +688,7 @@ describe('deidentifyFile', () => {
 
         const result = await promise;
         expect(mockVaultClient.filesAPI.deidentifySpreadsheet).toHaveBeenCalled();
-        expect(result.file).toBe('sheetProcessedFile');
+        expect(result.fileBase64).toBe('sheetProcessedFile');
         expect(result.type).toBe('xlsx');
         expect(result.extension).toBe('xlsx');
         expect(result.wordCount).toBe(8);
@@ -699,7 +699,7 @@ describe('deidentifyFile', () => {
 
     test('should successfully deidentify a ppt file and poll until SUCCESS', async () => {
         const file = new File(['ppt content'], 'test.pptx', { type: 'application/vnd.openxmlformats-officedocument.presentationml.presentation' });
-        const deidentifyFileReq = new DeidentifyFileRequest(file);
+        const deidentifyFileReq = new DeidentifyFileRequest({file});
         const options = new DeidentifyFileOptions();
 
         mockVaultClient.filesAPI.deidentifyPresentation.mockImplementation(() => ({
@@ -735,7 +735,7 @@ describe('deidentifyFile', () => {
         await jest.runAllTimersAsync();
 
         const result = await promise;
-        expect(result.file).toBe('pptProcessedFile');
+        expect(result.fileBase64).toBe('pptProcessedFile');
         expect(result.type).toBe('pptx');
         expect(result.extension).toBe('pptx');
         expect(result.wordCount).toBe(3);
@@ -747,7 +747,7 @@ describe('deidentifyFile', () => {
 
     test('should successfully deidentify a structured text file and poll until SUCCESS', async () => {
         const file = new File(['json content'], 'test.json', { type: 'application/json' });
-        const deidentifyFileReq = new DeidentifyFileRequest(file);
+        const deidentifyFileReq = new DeidentifyFileRequest({file});
         const options = new DeidentifyFileOptions();
 
         mockVaultClient.filesAPI.deidentifyStructuredText.mockImplementation(() => ({
@@ -783,7 +783,7 @@ describe('deidentifyFile', () => {
         await jest.runAllTimersAsync();
 
         const result = await promise;
-        expect(result.file).toBe('jsonProcessedFile');
+        expect(result.fileBase64).toBe('jsonProcessedFile');
         expect(result.type).toBe('json');
         expect(result.extension).toBe('json');
         expect(result.wordCount).toBe(6);
@@ -794,7 +794,7 @@ describe('deidentifyFile', () => {
 
     test('should successfully deidentify a document file and poll until SUCCESS', async () => {
         const file = new File(['doc content'], 'test.docx', { type: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document' });
-        const deidentifyFileReq = new DeidentifyFileRequest(file);
+        const deidentifyFileReq = new DeidentifyFileRequest({file});
         const options = new DeidentifyFileOptions();
 
         mockVaultClient.filesAPI.deidentifyDocument.mockImplementation(() => ({
@@ -830,7 +830,7 @@ describe('deidentifyFile', () => {
         await jest.runAllTimersAsync();
 
         const result = await promise;
-        expect(result.file).toBe('docProcessedFile');
+        expect(result.fileBase64).toBe('docProcessedFile');
         expect(result.type).toBe('docx');
         expect(result.extension).toBe('docx');
         expect(result.wordCount).toBe(7);
@@ -842,7 +842,7 @@ describe('deidentifyFile', () => {
 
     test('should successfully deidentify a text file and poll until SUCCESS', async () => {
         const file = new File(['doc content'], 'test.txt');
-        const deidentifyFileReq = new DeidentifyFileRequest(file);
+        const deidentifyFileReq = new DeidentifyFileRequest({file});
         const options = new DeidentifyFileOptions();
 
         mockVaultClient.filesAPI.deidentifyText.mockImplementation(() => ({
@@ -878,7 +878,7 @@ describe('deidentifyFile', () => {
         await jest.runAllTimersAsync();
 
         const result = await promise;
-        expect(result.file).toBe('textProcessedFile');
+        expect(result.fileBase64).toBe('textProcessedFile');
         expect(result.extension).toBe('txt');
         expect(result.wordCount).toBe(7);
         expect(result.charCount).toBe(70);
@@ -889,7 +889,7 @@ describe('deidentifyFile', () => {
 
     test('should successfully deidentify a generic file and poll until SUCCESS', async () => {
         const file = new File(['generic content'], 'test.abc', { type: 'application/octet-stream' });
-        const deidentifyFileReq = new DeidentifyFileRequest(file);
+        const deidentifyFileReq = new DeidentifyFileRequest({file});
         const options = new DeidentifyFileOptions();
 
         mockVaultClient.filesAPI.deidentifyFile.mockImplementation(() => ({
@@ -925,7 +925,7 @@ describe('deidentifyFile', () => {
         await jest.runAllTimersAsync();
 
         const result = await promise;
-        expect(result.file).toBe('genProcessedFile');
+        expect(result.fileBase64).toBe('genProcessedFile');
         expect(result.type).toBe('abc');
         expect(result.extension).toBe('abc');
         expect(result.wordCount).toBe(4);
@@ -937,7 +937,7 @@ describe('deidentifyFile', () => {
     test('should successfully deidentify a PDF file and save processed file to output directory', async () => {
 
         const pdfFile = new File(['dummy content'], 'test.pdf', { type: 'application/pdf' });
-        const pdfRequest = new DeidentifyFileRequest(pdfFile);
+        const pdfRequest = new DeidentifyFileRequest({file: pdfFile});
 
         const mockOptions = new DeidentifyFileOptions();
         mockOptions.setWaitTime(16);


### PR DESCRIPTION
## Why:
- Cloudflare throws an "invalid output directory" error when we provide a output directory to save file during the file deidentification
- So adding file object in the response so that users can have access to file in the response
- And adding file pat in the deidentify file request to make it consistent with the response

## Goal
- The deidentify request should contain file path along with file object 
- And response should contain file object

## Testing
- Tested the changes in local env