### PR TITLE
SK-2137 samples and README for deidentify file changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2186,11 +2186,16 @@ import {
 
 try {
   // Step 1: Prepare the file to be deidentified
-  const buffer = fs.readFileSync('<FILE_PATH>');
-  const file = new File([buffer], '<FILE_PATH>');
-  const fileReq = new DeidentifyFileRequest(file);
+  const filePath: string = '<FILE_PATH>';
+  const buffer = fs.readFileSync(filePath);
+  const file = new File([buffer], filePath);
 
-  // Step 2: Configure DeidentifyFileOptions
+  //Step 2: Construct the file input by providing either file or filePath but not both
+  const fileInput: FileInput = { file: file }
+  // const fileInput: FileInput = { filePath: filePath }
+  const fileReq = new DeidentifyFileRequest(fileInput);
+
+  // Step 3: Configure DeidentifyFileOptions
   const options = new DeidentifyFileOptions();
   options.setEntities([DetectEntities.SSN, DetectEntities.ACCOUNT_NUMBER]);
   options.setAllowRegexList(['<YOUR_REGEX_PATTERN>']);
@@ -2208,7 +2213,7 @@ try {
   });
   options.setTransformations(transformations);
 
-  options.setOutputDirectory('<OUTPUT_DIRECTORY_PATH>');  // Output directory for saving the deidentified file
+  options.setOutputDirectory('<OUTPUT_DIRECTORY_PATH>');  // Output directory for saving the deidentified file. This is not supported in Cloudflare workers
 
   options.setWaitTime(15);   // Wait time for response (max 64 seconds; throws error if more)
 
@@ -2239,7 +2244,7 @@ try {
   // bleep.setStopPadding(0.2);  // Padding at end in seconds
   // options.setBleep(bleep);
 
-  // Step 3: Call deidentifyFile
+  // Step 4: Call deidentifyFile
   const response: DeidentifyFileResponse = await skyflowClient
     .detect(primaryVaultConfig.vaultId)
     .deidentifyFile(fileReq, options);
@@ -2284,13 +2289,20 @@ import fs from 'fs';
 
 async function performDeidentifyFile() {
   try {
-    // Step 4: Prepare Deidentify File Request
+    // Step 1: Prepare Deidentify File Request
     // Replace with your file object (e.g., from fs.readFileSync or browser File API)
-    const buffer = fs.readFileSync('/detect/sample.txt');
-    const file = new File([buffer], '/detect/sample.txt');
-    const fileReq = new DeidentifyFileRequest(file);
+    const filePath: string = '/detect/sample.txt';
+    const buffer = fs.readFileSync(filePath);
+    const file = new File([buffer], filePath);
 
-    // Step 5: Configure DeidentifyFileOptions
+
+    //Step 2: Construct the file input by providing either file or filePath but not both
+    const fileInput: FileInput = { file: file }
+    // const fileInput: FileInput = { filePath: filePath }
+
+    const fileReq = new DeidentifyFileRequest(fileInput);
+
+    // Step 3: Configure DeidentifyFileOptions
     const options = new DeidentifyFileOptions();
 
     // Entities to detect and deidentify
@@ -2311,13 +2323,13 @@ async function performDeidentifyFile() {
     options.setTransformations(transformations);
 
     // Output directory for saving the deidentified file
-    options.setOutputDirectory('/home/user/output'); // Replace with your desired output directory
+    options.setOutputDirectory('/home/user/output'); // Replace with your desired output directory. This is not supported in Cloudflare workers
 
     // Wait time for response (max 64 seconds)
     options.setWaitTime(15);
 
 
-    // Step 6: Call deidentifyFile API
+    // Step 4: Call deidentifyFile API
     const response: DeidentifyFileResponse = await skyflowClient
       .detect(primaryVaultConfig.vaultId)
       .deidentifyFile(fileReq, options);
@@ -2354,7 +2366,13 @@ Sample Response:
       extension: 'json'
     }
   ],
-  file: 'TXkgU1NOIGlzIFtTU0==',
+  fileBase64: 'TXkgU1NOIGlzIFtTU0==',
+  file: File {
+    size: 15075,
+    type: '',
+    name: 'deidentified.jpeg',
+    lastModified: 1750791985426
+  },
   type: 'redacted_file',
   extension: 'txt',
   wordCount: 12,

--- a/samples/detect-api/deidentify-file-with-filepath.ts
+++ b/samples/detect-api/deidentify-file-with-filepath.ts
@@ -1,0 +1,148 @@
+import {
+    Credentials,
+    Env,
+    LogLevel,
+    Skyflow,
+    SkyflowConfig,
+    SkyflowError,
+    DeidentifyFileRequest,
+    DeidentifyFileOptions,
+    DetectEntities,
+    MaskingMethod,
+    DetectOutputTranscription,
+    TokenFormat,
+    TokenType,
+    Transformations,
+    Bleep,
+    VaultConfig,
+    DeidentifyFileResponse,
+    FileInput,
+  } from 'skyflow-node'; 
+  import fs from 'fs';
+  
+  /**
+   * Skyflow Deidentify File Example
+   * 
+   * This sample demonstrates how to use all available options for deidentifying files.
+   * Supported file types: images (jpg, png, etc.), pdf, audio (mp3, wav), documents, spreadsheets, presentations, structured text.
+   * 
+   * Note: File deidentification requires Node.js version 20 or above.
+   */
+  
+  async function performDeidentifyFile() {
+    try {
+      // Step 1: Configure Credentials
+      const credentials: Credentials = {
+        path: 'path-to-credentials-json', // Path to credentials file
+      };
+  
+      // Step 2: Configure Vault
+      const primaryVaultConfig: VaultConfig = {
+        vaultId: '<VAULT_ID>',
+        clusterId: '<CLUSTER_ID>',
+        env: Env.PROD,
+        credentials: credentials,
+      };
+  
+      // Step 3: Configure Skyflow Client
+      const skyflowConfig: SkyflowConfig = {
+        vaultConfigs: [primaryVaultConfig],
+        logLevel: LogLevel.INFO,        // Recommended to use LogLevel.ERROR in production environment.
+      };
+  
+      // Initialize Skyflow Client
+      const skyflowClient: Skyflow = new Skyflow(skyflowConfig);
+  
+      // Step 4: Prepare Deidentify File Request
+      // Replace with your file object (e.g., from fs.readFileSync or browser File API)
+
+      const filePath: string = '<FILE_PATH>'; // Replace with the path to your file
+
+      // Pass wither file object or file path, but not both.
+      const fileInput: FileInput = {
+        filePath
+      }
+
+      const deidentifyFile = new DeidentifyFileRequest(fileInput);
+  
+      // Step 5: Configure DeidentifyFileOptions
+      const options = new DeidentifyFileOptions();
+  
+      // Entities to detect and deidentify
+      options.setEntities([DetectEntities.SSN, DetectEntities.CREDIT_CARD]);
+  
+      // Allowlist regex patterns (entities matching these will NOT be deidentified)
+      options.setAllowRegexList(['<YOUR_REGEX_PATTERN>']);
+  
+      // Restrict deidentification to entities matching these regex patterns
+      options.setRestrictRegexList(['<YOUR_REGEX_PATTERN>']);
+  
+      // Token format for deidentified entities
+      const tokenFormat = new TokenFormat();
+      tokenFormat.setDefault(TokenType.ENTITY_ONLY);
+      options.setTokenFormat(tokenFormat);
+  
+      // Custom transformations for entities
+      // const transformations = new Transformations(); // Transformations cannot be applied to Documents, Images, or PDFs file formats.
+      // transformations.setShiftDays({
+      //   max: 30,
+      //   min: 10,
+      //   entities: [DetectEntities.SSN],
+      // });
+      // options.setTransformations(transformations);
+  
+      // Output directory for saving the deidentified file
+      // Providing an output directory is not supported in Cloudflare Workers
+      options.setOutputDirectory('<OUTPUT_DIRECTORY_PATH>'); // Replace with your output directory
+  
+      // Wait time for response (max 64 seconds)
+      options.setWaitTime(15);
+  
+      // --- Image Options (apply when file is an image) ---
+      // options.setOutputProcessedImage(true); // Include processed image in output
+      // options.setOutputOcrText(true);        // Include OCR text in response
+      // options.setMaskingMethod(MaskingMethod.Blackbox); // Masking method for image entities
+  
+      // --- PDF Options (apply when file is a PDF) ---
+      // options.setPixelDensity(1.5); // Pixel density for PDF processing
+      // options.setMaxResolution(2000); // Max resolution for PDF
+  
+      // --- Audio Options (apply when file is audio) ---
+      // options.setOutputProcessedAudio(true); // Include processed audio in output
+      // options.setOutputTranscription(DetectOutputTranscription.PLAINTEXT_TRANSCRIPTION); // Type of transcription
+  
+      // Bleep audio configuration
+      // const bleep = new Bleep();
+      // bleep.setGain(5);           // Loudness in dB
+      // bleep.setFrequency(1000);   // Pitch in Hz
+      // bleep.setStartPadding(0.1); // Padding at start in seconds
+      // bleep.setStopPadding(0.2);  // Padding at end in seconds
+      // options.setBleep(bleep);
+  
+  
+      // Step 6: Call deidentifyFile API
+      const response: DeidentifyFileResponse = await skyflowClient
+        .detect(primaryVaultConfig.vaultId)
+        .deidentifyFile(deidentifyFile, options);
+  
+      // Handle Successful Response
+      console.log('Deidentify File Response:', response);
+      console.log('Deidentified File:', response.file);
+      console.log('Deidentified File base64:', response.fileBase64);
+  
+    } catch (error) {
+        // Comprehensive Error Handling
+        if (error instanceof SkyflowError) {
+            console.error('Skyflow Specific Error:', {
+                code: error.error?.http_code,
+                message: error.message,
+                details: error.error?.details,
+            });
+        } else {
+            console.error('Unexpected Error:', JSON.stringify(error));
+        }
+    }
+  }
+  
+  // Invoke the deidentify file function
+  performDeidentifyFile();

--- a/samples/detect-api/deidentify-file.ts
+++ b/samples/detect-api/deidentify-file.ts
@@ -16,6 +16,7 @@ import {
   Bleep,
   VaultConfig,
   DeidentifyFileResponse,
+  FileInput,
 } from 'skyflow-node'; 
 import fs from 'fs';
 
@@ -54,9 +55,16 @@ async function performDeidentifyFile() {
 
     // Step 4: Prepare Deidentify File Request
     // Replace with your file object (e.g., from fs.readFileSync or browser File API)
-    const buffer = fs.readFileSync('<FILE_PATH>'); // Replace with the path to your file
-    const file = new File([buffer], '<FILE_PATH>');
-    const deidentifyFile = new DeidentifyFileRequest(file);
+    const filePath = '<FILE_PATH>'; // Replace with the path to your file
+    const buffer = fs.readFileSync(filePath);
+    const file = new File([buffer], filePath);
+
+    // Pass wither file object or file path, but not both.
+    const fileInput: FileInput = {
+      file
+    }
+
+    const deidentifyFile = new DeidentifyFileRequest(fileInput);
 
     // Step 5: Configure DeidentifyFileOptions
     const options = new DeidentifyFileOptions();
@@ -119,6 +127,8 @@ async function performDeidentifyFile() {
 
     // Handle Successful Response
     console.log('Deidentify File Response:', response);
+    console.log('Deidentified File:', response.file);
+    console.log('Deidentified File base64:', response.fileBase64);
 
   } catch (error) {
       // Comprehensive Error Handling

--- a/samples/package-lock.json
+++ b/samples/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "skyflow-node": "2.1.0-beta.1"
+        "skyflow-node": "2.2.0-beta.1"
       }
     },
     "node_modules/@babel/runtime": {
@@ -698,9 +698,9 @@
       }
     },
     "node_modules/skyflow-node": {
-      "version": "2.1.0-beta.1",
-      "resolved": "https://registry.npmjs.org/skyflow-node/-/skyflow-node-2.1.0-beta.1.tgz",
-      "integrity": "sha512-tzGdRMBMHSYcrM+dn/ndr7M1d2wiqv6dvuz57GXsF3yercN5+g+AwY6OGBknfG4fNUQVQBlHaFGTNFSLaIT3lQ==",
+      "version": "2.2.0-beta.1",
+      "resolved": "https://registry.npmjs.org/skyflow-node/-/skyflow-node-2.2.0-beta.1.tgz",
+      "integrity": "sha512-2Jic4OSqDbKtGtBDA/4p9t2hKNFsGdLqBHgKaJfxGl9r1pZD5ldqakWDaqgkT3+j+xMKw0NzeHCEWu/I/pUPhQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.27.1",

--- a/samples/package.json
+++ b/samples/package.json
@@ -9,6 +9,6 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "skyflow-node": "2.1.0-beta.1"
+    "skyflow-node": "2.2.0-beta.1"
   }
 }


### PR DESCRIPTION
## Why
- In the latest Node SKD v2 beta release, we have included file path in deidentify file request and file object in the response. So, there is slight change in the request structure also

## Goal
- Samples and README for deidentify file should be up to date

## Testing
- Tested the samples in local