### PR TITLE
SK-1729: Public Release V2

### DIFF
--- a/.github/workflows/common-ci.yml
+++ b/.github/workflows/common-ci.yml
@@ -15,7 +15,6 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: '20.x'
-          registry-url: "https://registry.npmjs.org"
 
       - name: Install Packages
         run: npm install

--- a/.github/workflows/common-release.yml
+++ b/.github/workflows/common-release.yml
@@ -19,6 +19,7 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: '20.x'
+          registry-url: "https://registry.npmjs.org"
 
       - name: Install Packages
         run: npm install

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skyflow-node",
-  "version": "2.0.0",
+  "version": "2.2.1-beta.1-dev.92e32df",
   "description": "Skyflow SDK for Node.js",
   "main": "./lib/index.js",
   "module": "./lib/index.js",


### PR DESCRIPTION
**Why**
- There is no GA availability for the v2 Node SDK.

**Outcome**
- A public release should be available.