### PR TITLE
SK-2771: fix deidentifyFile crash when waitTime is exceeded before processing completes

### DIFF
--- a/src/vault/controller/detect/index.ts
+++ b/src/vault/controller/detect/index.ts
@@ -352,7 +352,7 @@ class DetectController {
                     if (response.status?.toUpperCase() === 'IN_PROGRESS'
 ) {
                         if (currentWaitTime >= maxWaitTime) {
-                            resolve({ data: { runId, status: 'IN_PROGRESS' }, runId });
+                            resolve({ data: { status: 'IN_PROGRESS' }, runId });
                         } else {
                             const nextWaitTime = currentWaitTime * 2;
                             let waitTime = 0;
@@ -605,7 +605,10 @@ class DetectController {
                 this.waitTime = options?.getWaitTime() ?? this.waitTime; 
 
                 var reqType : DeidenitfyFileRequestTypes = this.getReqType(fileExtension); 
-                var promiseReq: Promise<{ data: DeidentifyFileDetectRunResponse & { runId?: string; status?: string }, runId: string }>;
+                type PollResult =
+                    | { data: DeidentifyFileDetectRunResponse; runId: string }
+                    | { data: { status: string }; runId: string };
+                var promiseReq: Promise<PollResult>;
                 switch (reqType){
                     case DeidenitfyFileRequestTypes.AUDIO:
                         promiseReq = this.buildAudioRequest(fileObj, options, fileExtension)
@@ -716,10 +719,11 @@ class DetectController {
                         }));
                         return;
                     }
-                    if (options?.getOutputDirectory() && data.status === "SUCCESS") {
-                        this.processDeidentifyFileResponse(data, options.getOutputDirectory() as string, fileBaseName);
+                    const fullResponse = data as DeidentifyFileDetectRunResponse;
+                    if (options?.getOutputDirectory() && fullResponse.status === "SUCCESS") {
+                        this.processDeidentifyFileResponse(fullResponse, options.getOutputDirectory() as string, fileBaseName);
                     }
-                    const deidentifiedFileResponse = this.parseDeidentifyFileResponse(data, runId, data.status);
+                    const deidentifiedFileResponse = this.parseDeidentifyFileResponse(fullResponse, runId, fullResponse.status);
                     resolve(deidentifiedFileResponse);
                 }).catch(error => {
                     reject(error)

--- a/src/vault/controller/detect/index.ts
+++ b/src/vault/controller/detect/index.ts
@@ -352,7 +352,7 @@ class DetectController {
                     if (response.status?.toUpperCase() === 'IN_PROGRESS'
 ) {
                         if (currentWaitTime >= maxWaitTime) {
-                            resolve({ runId }); // Resolve with runId if max wait time is exceeded
+                            resolve({ data: { runId, status: 'IN_PROGRESS' }, runId });
                         } else {
                             const nextWaitTime = currentWaitTime * 2;
                             let waitTime = 0;
@@ -368,7 +368,7 @@ class DetectController {
                             }, waitTime * 1000);
                         }
                     } else if (response.status?.toUpperCase() === 'SUCCESS') {
-                        resolve([response, runId]); // Resolve with the processed file response and runId
+                        resolve({ data: response, runId });
                     }
                     else if (response.status?.toUpperCase() === 'FAILED') {
                         reject(new SkyflowError(SKYFLOW_ERROR_CODE.INTERNAL_SERVER_ERROR, [response.message]));
@@ -605,7 +605,7 @@ class DetectController {
                 this.waitTime = options?.getWaitTime() ?? this.waitTime; 
 
                 var reqType : DeidenitfyFileRequestTypes = this.getReqType(fileExtension); 
-                var promiseReq: Promise<[DeidentifyFileDetectRunResponse, string]>;
+                var promiseReq: Promise<{ data: DeidentifyFileDetectRunResponse & { runId?: string; status?: string }, runId: string }>;
                 switch (reqType){
                     case DeidenitfyFileRequestTypes.AUDIO:
                         promiseReq = this.buildAudioRequest(fileObj, options, fileExtension)
@@ -708,12 +708,13 @@ class DetectController {
                         break;                    
                 }
 
-                promiseReq.then(([data, runId])  => {
+                promiseReq.then(({ data, runId })  => {
                     if(runId && data.status === "IN_PROGRESS") {
                         resolve(new DeidentifyFileResponse({
                             runId: runId,
                             status: data.status,
                         }));
+                        return;
                     }
                     if (options?.getOutputDirectory() && data.status === "SUCCESS") {
                         this.processDeidentifyFileResponse(data, options.getOutputDirectory() as string, fileBaseName);

--- a/test/vault/controller/detect.test.js
+++ b/test/vault/controller/detect.test.js
@@ -1059,4 +1059,54 @@ describe('deidentifyFile', () => {
             expect.any(Buffer)
         );
     });
+
+    test('should return runId and IN_PROGRESS status when waitTime is exceeded before processing completes', async () => {
+        const file = new File(['dummy content'], 'test.pdf', { type: 'application/pdf' });
+        const request = new DeidentifyFileRequest({ file });
+        const options = new DeidentifyFileOptions();
+        options.setWaitTime(1); // very small waitTime — will expire immediately
+
+        mockVaultClient.filesAPI.deidentifyPdf.mockImplementation(() => ({
+            withRawResponse: jest.fn().mockResolvedValue({
+                data: { run_id: 'run123' },
+                rawResponse: { headers: { get: jest.fn().mockReturnValue('req-id') } },
+            }),
+        }));
+
+        // Always IN_PROGRESS — never finishes within waitTime
+        mockVaultClient.filesAPI.getRun.mockResolvedValue({ status: 'IN_PROGRESS' });
+
+        const promise = detectController.deidentifyFile(request, options);
+        await jest.runAllTimersAsync();
+        const result = await promise;
+
+        expect(result.runId).toBe('run123');
+        expect(result.status).toBe('IN_PROGRESS');
+    });
+
+    test('should not call parseDeidentifyFileResponse when waitTime is exceeded (IN_PROGRESS early return)', async () => {
+        const file = new File(['dummy content'], 'test.pdf', { type: 'application/pdf' });
+        const request = new DeidentifyFileRequest({ file });
+        const options = new DeidentifyFileOptions();
+        options.setWaitTime(1);
+
+        mockVaultClient.filesAPI.deidentifyPdf.mockImplementation(() => ({
+            withRawResponse: jest.fn().mockResolvedValue({
+                data: { run_id: 'run456' },
+                rawResponse: { headers: { get: jest.fn().mockReturnValue('req-id') } },
+            }),
+        }));
+
+        mockVaultClient.filesAPI.getRun.mockResolvedValue({ status: 'IN_PROGRESS' });
+
+        const promise = detectController.deidentifyFile(request, options);
+        await jest.runAllTimersAsync();
+        const result = await promise;
+
+        // Only runId and status should be set — no file data
+        expect(result.runId).toBe('run456');
+        expect(result.status).toBe('IN_PROGRESS');
+        expect(result.fileBase64).toBeUndefined();
+        expect(result.extension).toBeUndefined();
+    });
 });


### PR DESCRIPTION
**Problem**
When waitTime is small and the file is still processing, the SDK crashed with TypeError: object is not iterable.

The poller resolved with { runId } (object) on timeout but [response, runId] (array) on success — the .then() handler always destructured as an array, causing the crash. A missing return also caused fall-through into response parsing with incomplete data.

**Changes**
Unified both resolve paths to consistent { data, runId } shape
Switched to named destructuring in .then() handler
Added return after IN_PROGRESS resolve to stop fall-through
Added unit tests for the timeout path
**Verification**
Tested locally with waitTime: 1 — previously crashed, now returns { runId, status: 'IN_PROGRESS' } cleanly.