### PR TITLE
SK-2770: publish v1.x releases under the v1 dist-tag to preserve latest as V2

### DIFF
--- a/.github/workflows/common-release.yml
+++ b/.github/workflows/common-release.yml
@@ -12,11 +12,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           token: ${{ secrets.PAT_ACTIONS }}
           fetch-depth: 0
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v4
         with:
           node-version: '20.x'
           registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/common-release.yml
+++ b/.github/workflows/common-release.yml
@@ -79,7 +79,12 @@ jobs:
           if [[ "${{ inputs.tag }}" == "beta" ]]; then
             npm publish --tag beta
           elif [[ "${{ inputs.tag }}" == "public" ]]; then
-            npm publish
+            MAJOR_VERSION=$(node -p "require('./package.json').version.split('.')[0]")
+            if [[ "$MAJOR_VERSION" == "1" ]]; then
+              npm publish --tag v1
+            else
+              npm publish
+            fi
           elif [[ "${{ inputs.tag }}" == "internal" ]]; then
             curl -u ${{ secrets.JFROG_USERNAME }}:${{ secrets.JFROG_PASSWORD }} https://prekarilabs.jfrog.io/prekarilabs/api/npm/auth/ > ~/.npmrc
             npm config set registry https://prekarilabs.jfrog.io/prekarilabs/api/npm/npm/


### PR DESCRIPTION
## Problem

Publishing a v1.x patch release via the public release workflow ran
`npm publish` without an explicit dist-tag. npm defaults to `latest`,
so every v1 patch silently overwrote the `latest` pointer away from v2.

## Solution

In `common-release.yml`, read the major version from `package.json`
(already bumped by `bump_version.sh` before this step) and branch:

- Major == `1` → `npm publish --tag v1`
- Major >= `2` → `npm publish` (keeps `latest` on v2)

## User impact

| Install command              | Gets               |
|------------------------------|--------------------|
| `npm install skyflow-node`   | latest v2 release  |
| `npm install skyflow-node@v1`| latest v1.x patch  |
| `npm install skyflow-node@beta` | beta (unchanged)|

No changes to trigger workflows or version-bumping logic.
