### PR TITLE
SK-2963: warn at startup when a beta/dev build targets a Production vault

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -3,6 +3,7 @@ import * as sdkDetails from "../../package.json";
 import { generateBearerToken, generateBearerTokenFromCreds } from "../service-account";
 import type { BearerTokenOptions } from "../service-account";
 import Credentials, { ApiKeyCredentials, PathCredentials, StringCredentials, TokenCredentials } from "../vault/config/credentials";
+import type VaultConfig from "../vault/config/vault";
 import dotenv from "dotenv";
 import logs from "./logs";
 import os from 'os';
@@ -17,6 +18,8 @@ dotenv.config();
 export const SDK = {
     METRICS_HEADER_KEY: "sky-metadata",
 } as const;
+
+export const SDK_VERSION: string = sdkDetails.version;
 
 export const SKYFLOW = {
     ID: "skyflowId",
@@ -366,6 +369,16 @@ export function getConnectionBaseURL(clusterId: string, env: Env) {
         default:
             return `https://${clusterId}.gateway.skyflowapis.com`;
     }
+}
+
+// Beta/dev builds are published as <major>.<minor>.<patch>-beta.<n> or
+// -dev.<sha> (see scripts/bump_version.sh); a plain public release has no suffix.
+export function isNonGaVersion(version?: string): boolean {
+    return !version || !/^\d+\.\d+\.\d+$/.test(version);
+}
+
+export function anyVaultIsProd(vaultConfigs?: VaultConfig[]): boolean {
+    return !!vaultConfigs?.some(vaultConfig => (vaultConfig.env || Env.PROD) === Env.PROD);
 }
 
 export function validateToken(token: string) {

--- a/src/utils/logs/index.ts
+++ b/src/utils/logs/index.ts
@@ -191,6 +191,7 @@ const logs = {
         DEPRECATED_HTTP_CODE_PROPERTY: "[DEPRECATED] Property 'http_code' is deprecated and will be removed in an upcoming release. Use 'httpCode' instead.",
         DEPRECATED_HTTP_STATUS_PROPERTY: "[DEPRECATED] Property 'http_status' is deprecated and will be removed in an upcoming release. Use 'httpStatus' instead.",
         DEPRECATED_GRPC_CODE_PROPERTY: "[DEPRECATED] Property 'grpc_code' is deprecated and will be removed in an upcoming release. Use 'grpcCode' instead.",
+        BETA_BUILD_WARNING: "This is a beta/pre-release build of the Skyflow SDK (v%s1). Beta builds are intended for acceptance testing only - you appear to be connecting to a Production vault. Contact your Skyflow representative before using this build in Production.",
     }
 };
 

--- a/src/vault/skyflow/index.ts
+++ b/src/vault/skyflow/index.ts
@@ -1,4 +1,4 @@
-import { CONFIG, CONTROLLER_TYPES, Env, getVaultURL, ISkyflowError, LogLevel, MessageType, parameterizedString, printLog } from "../../utils";
+import { anyVaultIsProd, CONFIG, CONTROLLER_TYPES, Env, getVaultURL, isNonGaVersion, ISkyflowError, LogLevel, MessageType, parameterizedString, printLog, SDK_VERSION } from "../../utils";
 import ConnectionConfig from "../config/connection";
 import VaultConfig from "../config/vault";
 import { SkyflowConfig, ClientObj } from "../types";
@@ -43,6 +43,9 @@ class Skyflow {
         config.connectionConfigs?.map(connectionConfig => {
             this.addConnectionConfig(connectionConfig);
         });
+        if (isNonGaVersion(SDK_VERSION) && anyVaultIsProd(config.vaultConfigs)) {
+            printLog(parameterizedString(logs.warnLogs.BETA_BUILD_WARNING, [SDK_VERSION]), MessageType.WARN, this.logLevel);
+        }
         printLog(logs.infoLogs.CLIENT_INITIALIZED, MessageType.LOG, this.logLevel);
     }
 

--- a/test/vault/skyflow/skyflow.beta-warning.test.js
+++ b/test/vault/skyflow/skyflow.beta-warning.test.js
@@ -1,0 +1,70 @@
+// SK-2963: beta-build-in-prod warning.
+//
+// Mocking package.json (rather than just unit-testing isNonGaVersion/anyVaultIsProd in
+// isolation, as utils.test.js does) lets us exercise the real end-to-end wiring in the
+// Skyflow constructor against a fake non-GA version, which Java's equivalent test can't
+// do against its own real (immutable, statically-filtered) SDK_VERSION constant.
+jest.mock('../../../package.json', () => ({
+    name: 'skyflow-node',
+    version: '99.0.0-beta.1',
+}));
+
+import { LogLevel, Skyflow, Env } from '../../../src';
+
+describe('Skyflow beta-build-in-prod warning (SK-2963)', () => {
+    const credentials = { apiKey: "sky-key" };
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        global.console = {
+            log: jest.fn(),
+            warn: jest.fn(),
+            error: jest.fn(),
+        };
+    });
+
+    test('warns when a non-GA build has a vault defaulting to PROD', () => {
+        new Skyflow({
+            vaultConfigs: [{ vaultId: 'v1', clusterId: 'c1', credentials }],
+            logLevel: LogLevel.WARN,
+        });
+
+        expect(console.warn).toHaveBeenCalledWith(
+            expect.stringContaining('beta/pre-release build')
+        );
+    });
+
+    test('warns when a non-GA build has an explicit PROD vault among others', () => {
+        new Skyflow({
+            vaultConfigs: [
+                { vaultId: 'v1', clusterId: 'c1', credentials, env: Env.SANDBOX },
+                { vaultId: 'v2', clusterId: 'c2', credentials, env: Env.PROD },
+            ],
+            logLevel: LogLevel.WARN,
+        });
+
+        expect(console.warn).toHaveBeenCalledWith(
+            expect.stringContaining('beta/pre-release build')
+        );
+    });
+
+    test('does not warn when every vault is non-PROD', () => {
+        new Skyflow({
+            vaultConfigs: [{ vaultId: 'v1', clusterId: 'c1', credentials, env: Env.SANDBOX }],
+            logLevel: LogLevel.WARN,
+        });
+
+        expect(console.warn).not.toHaveBeenCalledWith(
+            expect.stringContaining('beta/pre-release build')
+        );
+    });
+
+    test('does not warn when the log level suppresses WARN', () => {
+        new Skyflow({
+            vaultConfigs: [{ vaultId: 'v1', clusterId: 'c1', credentials, env: Env.PROD }],
+            logLevel: LogLevel.ERROR,
+        });
+
+        expect(console.warn).not.toHaveBeenCalled();
+    });
+});

--- a/test/vault/utils/utils.test.js
+++ b/test/vault/utils/utils.test.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 import errorMessages from "../../../src/error/messages";
-import { Env, getConnectionBaseURL, getVaultURL, validateToken, isValidURL, fillUrlWithPathAndQueryParams, generateSDKMetrics, printLog, getToken, getBearerToken, getBaseUrl, removeSDKVersion, parameterizedString, MessageType, LogLevel, objectToXML } from "../../../src/utils";
+import { Env, getConnectionBaseURL, getVaultURL, validateToken, isValidURL, fillUrlWithPathAndQueryParams, generateSDKMetrics, printLog, getToken, getBearerToken, getBaseUrl, removeSDKVersion, parameterizedString, MessageType, LogLevel, objectToXML, isNonGaVersion, anyVaultIsProd } from "../../../src/utils";
 import { jwtDecode as jwt_decode } from 'jwt-decode';
 import os from 'os';
 import { generateBearerTokenFromCreds, generateBearerToken } from '../../../src/service-account';
@@ -35,6 +35,48 @@ describe('Vault URL Helper', () => {
         test(`should return ${description}`, () => {
             expect(getVaultURL(clusterId, env)).toBe(expected);
         });
+    });
+});
+
+// SK-2963: beta-build-in-prod warning
+describe('isNonGaVersion', () => {
+    test.each([
+        ['1.0.0', false],
+        ['2.11.3', false],
+        ['2.1.0-beta.1', true],
+        ['2.1.0-dev.18f8f1ba', true],
+        ['3.0.0-beta.13-dev.18f8f1ba', true],
+        [undefined, true],
+        ['', true],
+        ['v2', true],
+    ])('isNonGaVersion(%p) should return %p', (version, expected) => {
+        expect(isNonGaVersion(version)).toBe(expected);
+    });
+});
+
+describe('anyVaultIsProd', () => {
+    test('returns false for an empty/undefined list', () => {
+        expect(anyVaultIsProd(undefined)).toBe(false);
+        expect(anyVaultIsProd([])).toBe(false);
+    });
+
+    test('returns false when no vault is PROD', () => {
+        expect(anyVaultIsProd([
+            { vaultId: 'v1', clusterId: 'c1', env: Env.DEV },
+            { vaultId: 'v2', clusterId: 'c2', env: Env.SANDBOX },
+            { vaultId: 'v3', clusterId: 'c3', env: Env.STAGE },
+        ])).toBe(false);
+    });
+
+    test('returns true when at least one of several vaults is PROD', () => {
+        expect(anyVaultIsProd([
+            { vaultId: 'v1', clusterId: 'c1', env: Env.DEV },
+            { vaultId: 'v2', clusterId: 'c2', env: Env.PROD },
+        ])).toBe(true);
+    });
+
+    test('treats an unset env as PROD (matches the default used to build the vault URL)', () => {
+        expect(anyVaultIsProd([{ vaultId: 'v1', clusterId: 'c1' }])).toBe(true);
     });
 });
 


### PR DESCRIPTION
## Summary

Corrective action from the Fifth Third Bank RCA (CUST-4287): a beta/pre-release SDK build ended up running in a customer's Production environment undetected. This adds a startup warning so that doesn't happen silently again.

Adds a WARN-level log, emitted once in the `Skyflow` constructor, when:
- the SDK's own version (`package.json`) is **non-GA** — any `-beta.N` or `-dev.<sha>` suffix, and
- at least one configured vault's `env` resolves to **`Env.PROD`** (its default).

Stays silent for legitimate Sandbox/Dev/Stage acceptance testing of a beta build, which is what betas are for.

## Changes

- `src/utils/index.ts`: `isNonGaVersion()` and `anyVaultIsProd()` — small pure functions, exported for direct unit testing (the real `SDK_VERSION` in this checkout is GA, so the true "warns" path can only be exercised by mocking `package.json`, not by exercising the real constant).
- `src/utils/logs/index.ts`: new `warnLogs.BETA_BUILD_WARNING` message template.
- `src/vault/skyflow/index.ts`: wires the check into the constructor, right before the existing `CLIENT_INITIALIZED` log. Respects the configured log level like every other warning in this SDK (won't print at the default `ERROR` level).

## Testing

- `test/vault/utils/utils.test.js`: unit tests for `isNonGaVersion` (GA/beta/dev/combined/undefined/garbage) and `anyVaultIsProd` (empty, none-prod, one-of-many-prod, unset-defaults-to-prod).
- `test/vault/skyflow/skyflow.beta-warning.test.js` (new): mocks `package.json` to a fake `99.0.0-beta.1` version and exercises the **real constructor end-to-end** — confirms it warns for a default/explicit PROD vault, stays silent when every vault is non-PROD, and stays silent when the log level suppresses WARN.
- Full suite: `npm run build` (tsc, clean), `npm run eslint` (clean), `npm test` — **1126/1126 passing**, zero regressions.

## Related

- Cross-SDK design + task tracking: SK-2963 (this is the reference-pattern implementation for skyflow-java; skyflow-python/go/js/... follow the same shape in their own repos).
- SK-2977 owns the final public-facing message wording — the copy here is a placeholder pending that sign-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)