### PR TITLE
SK-2977 add beta build disclaimer banner to README on release

### DIFF
--- a/.github/workflows/common-release.yml
+++ b/.github/workflows/common-release.yml
@@ -66,6 +66,7 @@ jobs:
             git checkout ${{ env.branch_name }}
           fi
           git add package.json
+          git add README.md
           if [[ "${{ inputs.tag }}" == "beta" || "${{ inputs.tag }}" == "public" ]]; then
             git commit -m "[AUTOMATED] Release - ${{ steps.previoustag.outputs.tag }}"
             git push origin ${{ env.branch_name }}

--- a/scripts/bump_version.sh
+++ b/scripts/bump_version.sh
@@ -6,6 +6,7 @@ then
 	echo "Bumping package version to $1"
 
 	sed -E "s/\"version\": .+/\"version\": \"$SEMVER\",/g" package.json > tempfile && cat tempfile > package.json && rm -f tempfile
+	./scripts/toggle_beta_banner.sh README.md "$SEMVER"
 	echo --------------------------
 	echo "Done, Package now at $1"
 

--- a/scripts/toggle_beta_banner.sh
+++ b/scripts/toggle_beta_banner.sh
@@ -1,36 +1,63 @@
 #!/usr/bin/env bash
+# Insert or remove the beta-release disclaimer banner in a README, based on
+# whether the given version string is a pre-release build.
+#
+# Usage: scripts/toggle_beta_banner.sh <readme-path> <version>
+#
+# Idempotent: safe to run repeatedly against the same file and version.
 set -euo pipefail
 
-if [ $# -ne 2 ]; then
-    echo "Usage: toggle_beta_banner.sh <readme-path> <version>"
-    exit 1
-fi
+readme_path="$1"
+version="$2"
 
-README_PATH="$1"
-VERSION="$2"
-MARKER_START="<!-- SKYFLOW-BETA-DISCLAIMER:START -->"
-MARKER_END="<!-- SKYFLOW-BETA-DISCLAIMER:END -->"
-BANNER_TEXT="$MARKER_START
-> **Note:** This is a beta release of the Skyflow Node.js SDK. APIs may change without notice.
-$MARKER_END"
+marker_start="<!-- SKYFLOW-BETA-DISCLAIMER:START -->"
+marker_end="<!-- SKYFLOW-BETA-DISCLAIMER:END -->"
+banner_body="> ⚠️ **Beta release — not for production use.** This is a pre-release build provided for early testing and feedback. It has not completed Skyflow's General Availability (GA) validation, its API may change before the stable release, and it is not covered by production SLAs or support commitments. Do not deploy beta builds to production environments."
 
-# Check if version contains "beta"
-if [[ "$VERSION" =~ -beta ]]; then
-    # Insert banner if it doesn't already exist
-    if ! grep -q "^$MARKER_START" "$README_PATH"; then
-        # Insert banner at the beginning of the file
-        {
-            echo "$BANNER_TEXT"
-            echo ""
-            cat "$README_PATH"
-        } > "$README_PATH.tmp"
-        mv "$README_PATH.tmp" "$README_PATH"
-    fi
-else
-    # Remove banner if it exists
-    if grep -q "^$MARKER_START" "$README_PATH"; then
-        sed -i "/^$MARKER_START/,/^$MARKER_END/d" "$README_PATH"
-        # Remove leading blank lines introduced by banner removal
-        sed -i '/./,$!d' "$README_PATH"
-    fi
+is_prerelease() {
+    [[ "$1" =~ -beta\.[0-9]+ ]]
+}
+
+# Strip any existing banner first, so re-running is idempotent regardless of
+# whether one is already present.
+awk -v start="$marker_start" -v end="$marker_end" '
+    { lines[NR] = $0 }
+    END {
+        start_line = 0
+        end_line = 0
+        for (i = 1; i <= NR; i++) {
+            if (lines[i] == start) start_line = i
+            if (lines[i] == end) end_line = i
+        }
+        if (start_line == 0 || end_line == 0) {
+            del_from = -1
+            del_to = -1
+        } else {
+            del_from = start_line
+            del_to = end_line
+            if (del_from > 1 && lines[del_from - 1] == "") del_from--
+            if (del_to < NR && lines[del_to + 1] == "") del_to++
+        }
+        for (i = 1; i <= NR; i++) {
+            if (i >= del_from && i <= del_to) continue
+            print lines[i]
+        }
+    }
+' "$readme_path" > "${readme_path}.tmp"
+mv "${readme_path}.tmp" "$readme_path"
+
+if is_prerelease "$version"; then
+    awk -v start="$marker_start" -v body="$banner_body" -v end="$marker_end" '
+        NR == 1 {
+            print
+            print ""
+            print start
+            print body
+            print end
+            print ""
+            next
+        }
+        { print }
+    ' "$readme_path" > "${readme_path}.tmp"
+    mv "${readme_path}.tmp" "$readme_path"
 fi

--- a/scripts/toggle_beta_banner.sh
+++ b/scripts/toggle_beta_banner.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ $# -ne 2 ]; then
+    echo "Usage: toggle_beta_banner.sh <readme-path> <version>"
+    exit 1
+fi
+
+README_PATH="$1"
+VERSION="$2"
+MARKER_START="<!-- SKYFLOW-BETA-DISCLAIMER:START -->"
+MARKER_END="<!-- SKYFLOW-BETA-DISCLAIMER:END -->"
+BANNER_TEXT="$MARKER_START
+> **Note:** This is a beta release of the Skyflow Node.js SDK. APIs may change without notice.
+$MARKER_END"
+
+# Check if version contains "beta"
+if [[ "$VERSION" =~ -beta ]]; then
+    # Insert banner if it doesn't already exist
+    if ! grep -q "^$MARKER_START" "$README_PATH"; then
+        # Insert banner at the beginning of the file
+        {
+            echo "$BANNER_TEXT"
+            echo ""
+            cat "$README_PATH"
+        } > "$README_PATH.tmp"
+        mv "$README_PATH.tmp" "$README_PATH"
+    fi
+else
+    # Remove banner if it exists
+    if grep -q "^$MARKER_START" "$README_PATH"; then
+        sed -i "/^$MARKER_START/,/^$MARKER_END/d" "$README_PATH"
+        # Remove leading blank lines introduced by banner removal
+        sed -i '/./,$!d' "$README_PATH"
+    fi
+fi

--- a/scripts/toggle_beta_banner.test.sh
+++ b/scripts/toggle_beta_banner.test.sh
@@ -5,6 +5,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 TOGGLE="$SCRIPT_DIR/toggle_beta_banner.sh"
 FIXTURE="$(mktemp)"
 MARKER_START="<!-- SKYFLOW-BETA-DISCLAIMER:START -->"
+BANNER_TEXT="> ⚠️ **Beta release — not for production use.** This is a pre-release build provided for early testing and feedback. It has not completed Skyflow's General Availability (GA) validation, its API may change before the stable release, and it is not covered by production SLAs or support commitments. Do not deploy beta builds to production environments."
 
 fail() {
     echo "FAIL: $1"
@@ -18,15 +19,23 @@ cat > "$FIXTURE" <<'EOF'
 Securely handle sensitive data intro text.
 EOF
 
+# Test 1: Banner is inserted for beta version
 "$TOGGLE" "$FIXTURE" "2.2.0-beta.1"
-[ "$(grep -c -F "$MARKER_START" "$FIXTURE")" -eq 1 ] || fail "banner not inserted for beta version"
+[ "$(grep -c -F "$MARKER_START" "$FIXTURE")" -eq 1 ] || fail "banner marker not inserted for beta version"
+grep -qF "$BANNER_TEXT" "$FIXTURE" || fail "banner text not found in file"
+[ "$(head -n 1 "$FIXTURE")" = "# Skyflow Node.js SDK" ] || fail "title moved after banner insertion"
 
+# Test 2: Banner is not duplicated on repeat run
 "$TOGGLE" "$FIXTURE" "2.2.0-beta.1"
 [ "$(grep -c -F "$MARKER_START" "$FIXTURE")" -eq 1 ] || fail "banner duplicated on repeat run"
+grep -qF "$BANNER_TEXT" "$FIXTURE" || fail "banner text lost after second run"
 
+# Test 3: Banner is removed for GA version
 "$TOGGLE" "$FIXTURE" "2.2.0"
 [ "$(grep -c -F "$MARKER_START" "$FIXTURE")" -eq 0 ] || fail "banner not removed for GA version"
+[ "$(head -n 1 "$FIXTURE")" = "# Skyflow Node.js SDK" ] || fail "title missing after banner removal"
 
+# Test 4: Original README content is preserved
 grep -qF "intro text." "$FIXTURE" || fail "original README content lost"
 
 rm -f "$FIXTURE"

--- a/scripts/toggle_beta_banner.test.sh
+++ b/scripts/toggle_beta_banner.test.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TOGGLE="$SCRIPT_DIR/toggle_beta_banner.sh"
+FIXTURE="$(mktemp)"
+MARKER_START="<!-- SKYFLOW-BETA-DISCLAIMER:START -->"
+
+fail() {
+    echo "FAIL: $1"
+    rm -f "$FIXTURE"
+    exit 1
+}
+
+cat > "$FIXTURE" <<'EOF'
+# Skyflow Node.js SDK
+
+Securely handle sensitive data intro text.
+EOF
+
+"$TOGGLE" "$FIXTURE" "2.2.0-beta.1"
+[ "$(grep -c -F "$MARKER_START" "$FIXTURE")" -eq 1 ] || fail "banner not inserted for beta version"
+
+"$TOGGLE" "$FIXTURE" "2.2.0-beta.1"
+[ "$(grep -c -F "$MARKER_START" "$FIXTURE")" -eq 1 ] || fail "banner duplicated on repeat run"
+
+"$TOGGLE" "$FIXTURE" "2.2.0"
+[ "$(grep -c -F "$MARKER_START" "$FIXTURE")" -eq 0 ] || fail "banner not removed for GA version"
+
+grep -qF "intro text." "$FIXTURE" || fail "original README content lost"
+
+rm -f "$FIXTURE"
+echo "PASS: toggle_beta_banner.sh"


### PR DESCRIPTION
## Summary
Adds a standard beta/pre-release disclaimer banner to the README, automatically toggled in and out by the existing release automation — part of the CUST-4287 RCA follow-up ([SK-2977](https://skyflow.atlassian.net/browse/SK-2977)).

- `scripts/toggle_beta_banner.sh` inserts the banner right after the README's title when the version being released is a `-beta.N` pre-release, and removes it on GA releases. Idempotent.
- Wired into `scripts/bump_version.sh` (public/beta path only — internal/dev builds are unaffected) and `common-release.yml` now stages `README.md` alongside `package.json` in its existing commit step.
- `scripts/toggle_beta_banner.test.sh` covers insertion, idempotency, GA removal, and content preservation (asserts the actual banner text, not just marker presence).

This is one of 8 sibling PRs (android, iOS, js, node, python, react-js, react-native, java) rolling out the same disclaimer text and mechanism across the SDKs. skyflow-go is deferred to a follow-up (no release CI to hook into today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SK-2977]: https://skyflow.atlassian.net/browse/SK-2977?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ