### PR TITLE
SK-3018 gitleaks fix

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,7 @@
+# False positives: Fern auto-generates example JWTs/UUID tokens in SDK doc comments (@example blocks) — not real secrets.
+a22a7c279fba8ce54b647845374492c41d0f9350:src/ _generated_/rest/api/resources/authentication/client/Client.ts:jwt:48
+a22a7c279fba8ce54b647845374492c41d0f9350:src/ _generated_/rest/api/resources/authentication/client/requests/V1GetAuthTokenRequest.ts:jwt:9
+a22a7c279fba8ce54b647845374492c41d0f9350:src/ _generated_/rest/api/resources/tokens/client/requests/V1DetokenizePayload.ts:generic-api-key:11
+a22a7c279fba8ce54b647845374492c41d0f9350:src/ _generated_/rest/api/resources/tokens/client/requests/V1DetokenizePayload.ts:generic-api-key:14
+a22a7c279fba8ce54b647845374492c41d0f9350:src/ _generated_/rest/api/resources/tokens/client/Client.ts:generic-api-key:47
+a22a7c279fba8ce54b647845374492c41d0f9350:src/ _generated_/rest/api/resources/tokens/client/Client.ts:generic-api-key:50


### PR DESCRIPTION
### Why:
The security team's Gitleaks scan flagged 6 findings in skyflow-node — jwt and generic-api-key rule matches in Fern-auto-generated SDK files under src/ _generated_/rest/api/resources/. These are example JWTs and UUID-format token IDs embedded in @example doc-comment blocks (used to illustrate SDK usage in generated docs), not real credentials. Confirmed by decoding the flagged JWT, which resolves to the generic placeholder payload {"sub":"1234567890","name":"John Doe",...}.

### Goal:
Suppress the 6 false-positive findings without touching the auto-generated source files (which would be overwritten on the next Fern codegen run anyway), using Gitleaks' native .gitleaksignore fingerprint suppression mechanism — consistent with the same fix applied in skyflow-react-native.